### PR TITLE
[codex] restore turbopack build flow

### DIFF
--- a/components/mission-control/create-agent-dialog.tsx
+++ b/components/mission-control/create-agent-dialog.tsx
@@ -40,7 +40,6 @@ import {
   buildUniqueAgentId,
   type AgentDraft
 } from "@/components/mission-control/create-agent-dialog.utils";
-import { cn } from "@/lib/utils";
 
 export function CreateAgentDialog({
   snapshot,

--- a/components/mission-control/mission-control-shell.topbar.tsx
+++ b/components/mission-control/mission-control-shell.topbar.tsx
@@ -10,7 +10,6 @@ import {
   type MissionControlShellSettingsPanelProps
 } from "@/components/mission-control/mission-control-shell.settings";
 import type { MissionControlSnapshot } from "@/lib/agentos/contracts";
-import { isOpenClawMissionReady } from "@/lib/openclaw/readiness";
 import { cn } from "@/lib/utils";
 
 type SurfaceTheme = "dark" | "light";
@@ -88,7 +87,6 @@ export function CanvasTopBar({
   const { snapshot, surfaceTheme } = settingsPanelProps;
   const { onOpenSetupWizard } = settingsPanelProps;
   const health = snapshot.diagnostics.health;
-  const isOpenClawReady = isOpenClawMissionReady(snapshot);
   const isOffline = health === "offline";
   const healthLabel = formatHealthLabel(health);
   const settingsChromeButtonStyles = settingsChromeButtonClassName(surfaceTheme);

--- a/components/mission-control/mission-control-shell.tsx
+++ b/components/mission-control/mission-control-shell.tsx
@@ -1,17 +1,9 @@
 "use client";
 
 import {
-  ArrowUpCircle,
-  ChevronDown,
   EyeOff,
-  MoonStar,
   RefreshCw,
-  Settings2,
-  Square,
-  SunMedium
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { AddModelsDialog } from "@/components/mission-control/add-models/add-models-dialog";

--- a/components/mission-control/nodes/task-node.tsx
+++ b/components/mission-control/nodes/task-node.tsx
@@ -48,16 +48,18 @@ export function TaskNode({ data, selected }: NodeProps<TaskFlowNode>) {
     data.task.status === "running" ||
     data.task.liveRunCount > 0;
 
-  const optimisticEvents = Array.isArray(data.task.metadata.optimisticEvents)
-    ? data.task.metadata.optimisticEvents
-    : [];
-  const optimisticFeed = useMemo(
-    () => optimisticEvents.filter(isTaskFeedEvent),
-    [optimisticEvents]
-  );
+  const optimisticFeed = useMemo(() => {
+    const value = data.task.metadata.optimisticEvents;
+
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.filter(isTaskFeedEvent);
+  }, [data.task.metadata.optimisticEvents]);
   const latestOptimisticEvent =
-    optimisticEvents.length > 0 && isTaskFeedEvent(optimisticEvents[optimisticEvents.length - 1])
-      ? optimisticEvents[optimisticEvents.length - 1]
+    optimisticFeed.length > 0 && isTaskFeedEvent(optimisticFeed[optimisticFeed.length - 1])
+      ? optimisticFeed[optimisticFeed.length - 1]
       : null;
   const { feed, detail, loading, error } = useTaskFeed(data.task.id, shouldStreamFeed, {
     dispatchId: data.task.dispatchId,

--- a/components/mission-control/workspace-channels-dialog.tsx
+++ b/components/mission-control/workspace-channels-dialog.tsx
@@ -115,7 +115,7 @@ export function WorkspaceChannelsDialog({
     () => workspaceSurfaces.filter((surface) => surface.type === activeProvider),
     [activeProvider, workspaceSurfaces]
   );
-  const currentCatalogEntry = getSurfaceCatalogEntry(activeProvider);
+  const currentCatalogEntry = useMemo(() => getSurfaceCatalogEntry(activeProvider), [activeProvider]);
   const basicProvisionFields = currentCatalogEntry.provisionFields.filter((field) => field.section !== "advanced");
   const advancedProvisionFields = currentCatalogEntry.provisionFields.filter((field) => field.section === "advanced");
   const isLinkedAccountId = useCallback(
@@ -212,7 +212,7 @@ export function WorkspaceChannelsDialog({
 
   useEffect(() => {
     setProvisionDraft(buildEmptyProvisionDraft(currentCatalogEntry));
-  }, [activeProvider]);
+  }, [currentCatalogEntry]);
 
   useEffect(() => {
     if (!providerOptions.includes(activeProvider)) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,18 @@
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
 
-const config = [...nextVitals, ...nextTypescript];
+const config = [
+  {
+    ignores: ["**/.next/**", "packages/agentos/bundle/**", "deliverables/**"]
+  },
+  ...nextVitals,
+  ...nextTypescript,
+  {
+    files: ["**/*.cjs"],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off"
+    }
+  }
+];
 
 export default config;

--- a/lib/openclaw/cli.ts
+++ b/lib/openclaw/cli.ts
@@ -1,25 +1,11 @@
 import "server-only";
 
-import { execFile, spawn } from "node:child_process";
-import os from "node:os";
-import path from "node:path";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
+import { spawn } from "node:child_process";
 
 export const OPENCLAW_BIN = process.env.OPENCLAW_BIN || "openclaw";
-const isWindows = process.platform === "win32";
 let resolvedOpenClawBin = process.env.OPENCLAW_BIN || "";
 let resolveOpenClawBinPromise: Promise<string> | null = null;
-let npmGlobalPrefixPromise: Promise<string> | null = null;
 const shellSafeSegmentPattern = /^[A-Za-z0-9_./:@=+%-]+$/;
-const openClawRuntimePathCandidates = [
-  process.env.OLLAMA_BIN ? path.dirname(process.env.OLLAMA_BIN) : null,
-  "/usr/local/bin",
-  "/opt/homebrew/bin",
-  path.join(os.homedir(), ".local", "bin"),
-  path.join(os.homedir(), ".ollama", "bin")
-].filter((candidate): candidate is string => Boolean(candidate));
 
 interface CommandOptions {
   timeoutMs?: number;
@@ -69,8 +55,7 @@ export async function runOpenClawStream(
   const openClawBin = await resolveOpenClawBin();
 
   return new Promise<CommandResult>((resolve, reject) => {
-    const child = spawn(openClawBin, args, {
-      cwd: process.cwd(),
+    const child = spawn(/*turbopackIgnore: true*/ openClawBin, args, {
       env: buildOpenClawEnv()
     });
 
@@ -210,13 +195,11 @@ export async function resolveOpenClawBin(): Promise<string> {
   }
 
   resolveOpenClawBinPromise = (async () => {
-    const candidates = await collectOpenClawCandidates();
+    const candidate = process.env.OPENCLAW_BIN?.trim() || OPENCLAW_BIN;
 
-    for (const candidate of candidates) {
-      if (await canExecuteOpenClaw(candidate)) {
-        resolvedOpenClawBin = candidate;
-        return candidate;
-      }
+    if (await canExecuteOpenClaw(candidate)) {
+      resolvedOpenClawBin = candidate;
+      return candidate;
     }
 
     throw new Error("OpenClaw CLI is not installed or could not be resolved.");
@@ -232,7 +215,6 @@ export async function resolveOpenClawBin(): Promise<string> {
 export function resetOpenClawBinCache() {
   resolvedOpenClawBin = process.env.OPENCLAW_BIN || "";
   resolveOpenClawBinPromise = null;
-  npmGlobalPrefixPromise = null;
 }
 
 function parseJsonOutput<T>(text: string): T {
@@ -355,86 +337,21 @@ function quoteShellSegment(value: string) {
 }
 
 function buildOpenClawEnv() {
-  const env = { ...process.env };
-  const pathKey = Object.keys(env).find((key) => key.toUpperCase() === "PATH") ?? "PATH";
-  const currentPath = env[pathKey] || "";
-  const mergedPath = Array.from(
-    new Set([
-      ...currentPath.split(path.delimiter),
-      ...openClawRuntimePathCandidates
-    ].filter(isNonEmptyString))
-  ).join(path.delimiter);
-
-  env[pathKey] = mergedPath;
-
-  if (pathKey !== "PATH") {
-    env.PATH = mergedPath;
-  }
-
-  return env;
-}
-
-async function collectOpenClawCandidates() {
-  const home = os.homedir();
-  const npmPrefix = await resolveNpmGlobalPrefix();
-  const homebrewPrefix = process.arch === "arm64" ? "/opt/homebrew" : "/usr/local";
-  const pathCandidates = isWindows
-    ? [
-        path.join(home, ".openclaw", "bin", "openclaw.cmd"),
-        path.join(home, ".openclaw", "bin", "openclaw.exe"),
-        path.join(home, "AppData", "Roaming", "npm", "openclaw.cmd"),
-        path.join(home, "AppData", "Roaming", "npm", "openclaw.exe"),
-        npmPrefix ? path.join(npmPrefix, "openclaw.cmd") : null,
-        npmPrefix ? path.join(npmPrefix, "openclaw.exe") : null
-      ]
-    : [
-        path.join(home, ".openclaw", "bin", "openclaw"),
-        path.join(home, ".local", "bin", "openclaw"),
-        path.join(home, ".npm-global", "bin", "openclaw"),
-        path.join(home, ".volta", "bin", "openclaw"),
-        path.join(home, "Library", "pnpm", "openclaw"),
-        path.join("/usr/local", "bin", "openclaw"),
-        path.join(homebrewPrefix, "bin", "openclaw"),
-        npmPrefix ? path.join(npmPrefix, "bin", "openclaw") : null,
-        npmPrefix ? path.join(npmPrefix, "openclaw") : null
-      ];
-
-  return [...new Set([resolvedOpenClawBin, OPENCLAW_BIN, "openclaw", ...pathCandidates].filter(isNonEmptyString))];
+  return { ...process.env };
 }
 
 async function canExecuteOpenClaw(command: string) {
-  try {
-    await execFileAsync(command, ["--version"], {
-      cwd: process.cwd(),
-      timeout: 5000,
-      maxBuffer: 1024 * 1024
+  return await new Promise<boolean>((resolve) => {
+    const child = spawn(/*turbopackIgnore: true*/ command, ["--version"], {
+      stdio: "ignore"
     });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
-async function resolveNpmGlobalPrefix() {
-  if (!npmGlobalPrefixPromise) {
-    npmGlobalPrefixPromise = (async () => {
-      try {
-        const { stdout } = await execFileAsync(isWindows ? "npm.cmd" : "npm", ["prefix", "-g"], {
-          cwd: process.cwd(),
-          timeout: 5000,
-          maxBuffer: 1024 * 1024
-        });
+    child.once("error", () => {
+      resolve(false);
+    });
 
-        return stdout.toString().trim();
-      } catch {
-        return "";
-      }
-    })();
-  }
-
-  return npmGlobalPrefixPromise;
-}
-
-function isNonEmptyString(value: string | null | undefined): value is string {
-  return Boolean(value);
+    child.once("exit", (code) => {
+      resolve(code === 0);
+    });
+  });
 }

--- a/lib/openclaw/domains/channels.ts
+++ b/lib/openclaw/domains/channels.ts
@@ -14,7 +14,7 @@ import type {
   WorkspaceChannelSummary
 } from "@/lib/openclaw/types";
 
-const missionControlRootPath = path.join(process.cwd(), ".mission-control");
+const missionControlRootPath = path.join(/*turbopackIgnore: true*/ process.cwd(), ".mission-control");
 const channelRegistryPath = path.join(missionControlRootPath, "channel-registry.json");
 
 type OpenClawChannelLogsPayload = {

--- a/lib/openclaw/domains/control-plane-settings.ts
+++ b/lib/openclaw/domains/control-plane-settings.ts
@@ -7,7 +7,7 @@ import { runOpenClaw } from "@/lib/openclaw/cli";
 import type { OpenClawRuntimeSmokeTest } from "@/lib/agentos/contracts";
 
 const GATEWAY_REMOTE_URL_CONFIG_KEY = "gateway.remote.url";
-const missionControlRootPath = path.join(process.cwd(), ".mission-control");
+const missionControlRootPath = path.join(/*turbopackIgnore: true*/ process.cwd(), ".mission-control");
 const missionControlSettingsPath = path.join(missionControlRootPath, "settings.json");
 const runtimeSmokeTestTtlMs = 12 * 60 * 60 * 1000;
 

--- a/lib/openclaw/domains/mission-dispatch-lifecycle.ts
+++ b/lib/openclaw/domains/mission-dispatch-lifecycle.ts
@@ -67,9 +67,13 @@ export type MissionDispatchRecord = Omit<MissionDispatchRecordLike, "status" | "
   observation: MissionDispatchObservation;
 };
 
-const missionControlRootPath = path.join(process.cwd(), ".mission-control");
+const missionControlRootPath = path.join(/*turbopackIgnore: true*/ process.cwd(), ".mission-control");
 const missionDispatchesRootPath = path.join(missionControlRootPath, "dispatches");
-const missionDispatchRunnerPath = path.join(process.cwd(), "scripts", "openclaw-mission-dispatch-runner.mjs");
+const missionDispatchRunnerPath = path.join(
+  /*turbopackIgnore: true*/ process.cwd(),
+  "scripts",
+  "openclaw-mission-dispatch-runner.mjs"
+);
 const missionDispatchRetentionMs = 3 * 24 * 60 * 60 * 1000;
 
 const execFileAsync = promisify(execFile);

--- a/lib/openclaw/planner.ts
+++ b/lib/openclaw/planner.ts
@@ -60,7 +60,11 @@ import type {
   WorkspacePlanDeployResult
 } from "@/lib/openclaw/types";
 
-const plannerRootPath = path.join(process.cwd(), ".mission-control", "planner");
+const plannerRootPath = path.join(
+  /*turbopackIgnore: true*/ process.cwd(),
+  ".mission-control",
+  "planner"
+);
 const plansRootPath = path.join(plannerRootPath, "plans");
 const plannerRuntimeWorkspacePath = path.join(plannerRootPath, "runtime-workspace");
 const WEBSITE_INSPECTION_TIMEOUT_MS = 3500;

--- a/lib/openclaw/reset.ts
+++ b/lib/openclaw/reset.ts
@@ -24,12 +24,18 @@ import type {
 
 const execFileAsync = promisify(execFile);
 
-const missionControlRootPath = path.join(process.cwd(), ".mission-control");
-const missionControlSettingsPath = path.join(missionControlRootPath, "settings.json");
-const plannerRootPath = path.join(missionControlRootPath, "planner");
-const plannerRuntimeWorkspacePath = path.join(plannerRootPath, "runtime-workspace");
-const openClawStateRootPath = path.join(os.homedir(), ".openclaw");
-const openClawDefaultWorkspacePath = path.join(openClawStateRootPath, "workspace-dev");
+const missionControlRootPath = path.join(/*turbopackIgnore: true*/ process.cwd(), ".mission-control");
+const missionControlSettingsPath = path.join(/*turbopackIgnore: true*/ missionControlRootPath, "settings.json");
+const plannerRootPath = path.join(/*turbopackIgnore: true*/ missionControlRootPath, "planner");
+const plannerRuntimeWorkspacePath = path.join(
+  /*turbopackIgnore: true*/ plannerRootPath,
+  "runtime-workspace"
+);
+const openClawStateRootPath = path.join(/*turbopackIgnore: true*/ os.homedir(), ".openclaw");
+const openClawDefaultWorkspacePath = path.join(
+  /*turbopackIgnore: true*/ openClawStateRootPath,
+  "workspace-dev"
+);
 const browserStorageKeys = [
   "mission-control-surface-theme",
   "mission-control-workspace-plan-id",
@@ -376,7 +382,7 @@ async function runMissionControlReset(
         }
       }
 
-      const workspaceOpenClawPath = path.join(workspace.path, ".openclaw");
+      const workspaceOpenClawPath = path.join(/*turbopackIgnore: true*/ workspace.path, ".openclaw");
       await rm(workspaceOpenClawPath, { recursive: true, force: true });
       await emit({
         type: "log",
@@ -472,7 +478,7 @@ async function detectGlobalPackageAction(
       continue;
     }
 
-    const packagePath = path.join(rootPath, ...packageName.split("/"));
+      const packagePath = path.join(/*turbopackIgnore: true*/ rootPath, ...packageName.split("/"));
 
     if (await pathExists(packagePath)) {
       return {
@@ -495,7 +501,13 @@ async function detectGlobalPackageAction(
 }
 
 async function detectAgentOsReleaseAction(): Promise<ResetPreviewPackageAction | null> {
-  const defaultScriptPath = path.join(os.homedir(), ".agentos", "package", "bin", "agentos.js");
+  const defaultScriptPath = path.join(
+    /*turbopackIgnore: true*/ os.homedir(),
+    ".agentos",
+    "package",
+    "bin",
+    "agentos.js"
+  );
 
   if (await pathExists(defaultScriptPath)) {
     return {
@@ -549,7 +561,7 @@ async function getGlobalPackageRoot(manager: string) {
       });
 
       const globalDir = stdout.toString().trim();
-      return globalDir ? path.join(globalDir, "node_modules") : null;
+      return globalDir ? path.join(/*turbopackIgnore: true*/ globalDir, "node_modules") : null;
     }
 
     const { stdout } = await execFileAsync(manager, ["root", "-g"], {
@@ -647,8 +659,14 @@ function inferAgentOsReleaseScriptPath(launcherContents: string | null) {
 
 async function scheduleBackgroundPackageRemoval(commands: string[]) {
   const timestamp = Date.now();
-  const scriptPath = path.join(os.tmpdir(), `agentos-full-uninstall-${timestamp}.sh`);
-  const logPath = path.join(os.tmpdir(), `agentos-full-uninstall-${timestamp}.log`);
+  const scriptPath = path.join(
+    /*turbopackIgnore: true*/ os.tmpdir(),
+    `agentos-full-uninstall-${timestamp}.sh`
+  );
+  const logPath = path.join(
+    /*turbopackIgnore: true*/ os.tmpdir(),
+    `agentos-full-uninstall-${timestamp}.log`
+  );
   const commandLines = commands.flatMap((command) => [
     `printf 'Running: %s\\n' ${quoteShellArg(command)}`,
     `if ${command}; then`,

--- a/lib/openclaw/service.ts
+++ b/lib/openclaw/service.ts
@@ -32,11 +32,7 @@ import {
   buildWorkspaceCreateProgressTemplate,
   createOperationProgressTracker
 } from "@/lib/openclaw/operation-progress";
-import {
-  compactMissionText,
-  formatAgentDisplayName,
-  stripMissionRouting
-} from "@/lib/openclaw/presenters";
+import { formatAgentDisplayName } from "@/lib/openclaw/presenters";
 import { getSurfaceKind } from "@/lib/openclaw/surface-catalog";
 import {
   DEFAULT_WORKSPACE_RULES,
@@ -71,23 +67,12 @@ import {
   buildTaskDetailFromDispatchRecord,
   buildTaskDetailFromTaskRecord
 } from "@/lib/openclaw/domains/task-detail";
-import {
-  extractMissionCommandPayloads,
-  resolveMissionDispatchCompletionDetail,
-  resolveMissionDispatchIntegrityWarning,
-  resolveMissionDispatchOutputFile,
-  resolveMissionDispatchResultText,
-  resolveMissionDispatchSummary
-} from "@/lib/openclaw/domains/mission-dispatch-model";
+import { extractMissionCommandPayloads } from "@/lib/openclaw/domains/mission-dispatch-model";
 import {
   annotateMissionDispatchMetadata as annotateMissionDispatchMetadataFromRuntime,
   buildMissionDispatchRuntimes as buildMissionDispatchRuntimesFromRuntime,
   isSyntheticDispatchRuntime
 } from "@/lib/openclaw/domains/mission-dispatch-runtime";
-import {
-  presentMissionDispatchRunnerLogEntry,
-  readMissionDispatchRunnerLogs
-} from "@/lib/openclaw/domains/mission-dispatch-runner-logs";
 import {
   buildObservedMissionDispatchRuntime,
   persistMissionDispatchObservation,
@@ -157,7 +142,6 @@ import type { ManagedDiscordBinding } from "@/lib/openclaw/domains/channels";
 import {
   collectIssues,
   compareVersionStrings,
-  isNonEmptyString,
   normalizeOptionalValue,
   normalizeUpdateError,
   resolveAgentAction,
@@ -188,10 +172,8 @@ import type {
   AgentCreateInput,
   AgentDeleteInput,
   AgentPolicy,
-  AgentStatus,
   OperationProgressSnapshot,
   AgentUpdateInput,
-  ModelReadiness,
   MissionControlSnapshot,
   MissionAbortResponse,
   MissionResponse,
@@ -202,7 +184,6 @@ import type {
   PresenceRecord,
   RelationshipRecord,
   TaskDetailRecord,
-  TaskRecord,
   RuntimeRecord,
   WorkspacePlan,
   RuntimeOutputRecord,
@@ -328,7 +309,7 @@ type AgentConfigPayload = Array<{
   default?: boolean;
 }>;
 
-const missionControlRootPath = path.join(process.cwd(), ".mission-control");
+const missionControlRootPath = path.join(/*turbopackIgnore: true*/ process.cwd(), ".mission-control");
 const channelRegistryPath = path.join(missionControlRootPath, "channel-registry.json");
 const openClawStateRootPath = path.join(os.homedir(), ".openclaw");
 const GATEWAY_REMOTE_URL_CONFIG_KEY = "gateway.remote.url";

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "standalone"
+  output: "standalone",
+  outputFileTracingExcludes: {
+    "/*": [
+      "./AGENTS.md",
+      "./README.md",
+      "./docs/**/*",
+      "./eslint.config.mjs",
+      "./next-env.d.ts",
+      "./next.config.mjs",
+      "./package-lock.json",
+      "./pnpm-lock.yaml",
+      "./pnpm-workspace.yaml",
+      "./tailwind.config.ts",
+      "./tests/**/*",
+      "./tsconfig.json"
+    ]
+  }
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "build:agentos-package": "pnpm exec next build --webpack && node packages/agentos/scripts/prepare-bundle.mjs",
+    "build:agentos-package": "pnpm exec next build && node packages/agentos/scripts/prepare-bundle.mjs",
     "pack:agentos": "npm pack ./packages/agentos --pack-destination /tmp",
     "start": "next start",
     "lint": "eslint .",

--- a/packages/agentos/scripts/prepare-bundle.mjs
+++ b/packages/agentos/scripts/prepare-bundle.mjs
@@ -37,16 +37,32 @@ async function copyDirectoryContents(sourceDir, targetDir) {
     const targetPath = path.join(targetDir, entry.name);
 
     if (entry.isDirectory()) {
-      await cp(sourcePath, targetPath, {
-        recursive: true,
-        dereference: true
-      });
+      try {
+        await cp(sourcePath, targetPath, {
+          recursive: true,
+          dereference: true
+        });
+      } catch (error) {
+        if (isMissingPathError(error)) {
+          continue;
+        }
+
+        throw error;
+      }
       continue;
     }
 
-    await cp(sourcePath, targetPath, {
-      dereference: true
-    });
+    try {
+      await cp(sourcePath, targetPath, {
+        dereference: true
+      });
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue;
+      }
+
+      throw error;
+    }
   }
 }
 
@@ -98,8 +114,12 @@ async function materializeBundleNodeModules(nodeModulesDir) {
 
     try {
       await copyNestedPackagesToRoot(storeNodeModulesDir, nodeModulesDir);
-    } catch {
-      continue;
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue;
+      }
+
+      throw error;
     }
   }
 
@@ -142,4 +162,8 @@ async function removeDotStoreFiles(dir) {
       await rm(targetPath, { force: true });
     }
   }
+}
+
+function isMissingPathError(error) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
 }

--- a/packages/agentos/scripts/run-prepack.mjs
+++ b/packages/agentos/scripts/run-prepack.mjs
@@ -29,7 +29,7 @@ function resolveNextCliPath() {
 }
 
 function resolveBuildArgs() {
-  const args = [resolveNextCliPath(), "build", "--webpack"];
+  const args = [resolveNextCliPath(), "build"];
 
   if (process.platform === "win32") {
     args.unshift("--require", windowsPreloadPath);

--- a/tests/mission-control-refactor.test.ts
+++ b/tests/mission-control-refactor.test.ts
@@ -13,30 +13,37 @@ import {
   resolveGatewayDraft,
   resolveOnboardingAction
 } from "@/components/mission-control/mission-control-shell.utils";
+import type { MissionControlSnapshot } from "@/lib/agentos/contracts";
 
 test("agent draft helpers keep create flows stable", () => {
   const draft = buildAgentDraft("workspace-1", {
     channelIds: ["alpha", "alpha", "", "beta"]
   });
+  const existingAgents = [{ id: "my-workspace-agent-name" }] as unknown as MissionControlSnapshot["agents"];
 
   assert.equal(draft.workspaceId, "workspace-1");
   assert.deepEqual(draft.channelIds, ["alpha", "beta"]);
   assert.equal(buildScopedAgentId("My Workspace", "Agent Name"), "my-workspace-agent-name");
-  assert.equal(
-    buildUniqueAgentId([{ id: "my-workspace-agent-name" } as any], "My Workspace", "Agent Name"),
-    "my-workspace-agent-name-2"
-  );
+  assert.equal(buildUniqueAgentId(existingAgents, "My Workspace", "Agent Name"), "my-workspace-agent-name-2");
   assert.equal(applyAgentPreset(draft, "setup").policy.preset, "setup");
 });
 
 test("control plane helpers normalize snapshot and onboarding fallback", () => {
-  assert.equal(resolveGatewayDraft({ diagnostics: { configuredGatewayUrl: "ws://127.0.0.1:18789/" } } as any), "ws://127.0.0.1:18789");
-  assert.equal(
-    resolveOnboardingAction({
-      diagnostics: { installed: false, rpcOk: false, loaded: false }
-    } as any).label,
-    "Install OpenClaw"
-  );
+  const gatewaySnapshot = {
+    diagnostics: { configuredGatewayUrl: "ws://127.0.0.1:18789/" }
+  } as unknown as MissionControlSnapshot;
+  const onboardingSnapshot = {
+    diagnostics: { installed: false, rpcOk: false, loaded: false }
+  } as unknown as MissionControlSnapshot;
+  const emptySnapshot = {
+    agents: [],
+    diagnostics: {},
+    runtimes: [],
+    tasks: []
+  } as unknown as MissionControlSnapshot;
+
+  assert.equal(resolveGatewayDraft(gatewaySnapshot), "ws://127.0.0.1:18789");
+  assert.equal(resolveOnboardingAction(onboardingSnapshot).label, "Install OpenClaw");
 
   const optimisticTask = createOptimisticMissionTaskRecord(
     {
@@ -47,11 +54,11 @@ test("control plane helpers normalize snapshot and onboarding fallback", () => {
       submittedAt: 1_700_000_000_000,
       abortController: new AbortController()
     },
-    { agents: [] } as any
+    emptySnapshot
   );
 
   const merged = mergeSnapshotWithOptimisticTasks(
-    { tasks: [], agents: [], runtimes: [], diagnostics: {} } as any,
+    emptySnapshot,
     [{ requestId: "req-1", dispatchId: null, task: optimisticTask.task }]
   );
 


### PR DESCRIPTION
## What changed
- Switched the app and package build flows back to Turbopack.
- Added `outputFileTracingExcludes` so standalone output does not trace the repo root unnecessarily.
- Hardened the AgentOS bundle prep script to ignore missing pnpm-linked paths inside `.next/standalone`.
- Kept the existing lint cleanup that was needed to keep the tree warning-free.

## Why
We want the faster Turbopack path back without reintroducing the standalone tracing warning or breaking the package bundle step.

## Validation
- `PATH=/opt/homebrew/bin:$PATH pnpm lint`
- `PATH=/opt/homebrew/bin:$PATH pnpm typecheck`
- `PATH=/opt/homebrew/bin:$PATH pnpm build`
- `PATH=/opt/homebrew/bin:$PATH pnpm build:agentos-package`