### PR TITLE
docs: add social account mission recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The 0.6.8 release expects Node.js 24 or newer and the OpenClaw supported baselin
 - AgentOS uses OpenClaw Gateway-first transport by default. CLI fallback remains explicit and visible for install, recovery, Gateway process control, older or unsupported Gateway methods, malformed responses, scope limits, and unavailable native auth.
 - Accounts and browser profiles are an MVP bridge. AgentOS can read OpenClaw browser profiles, start or attach a reported profile, open a login target, and enforce AgentOS access rules before account-target task launch. OpenClaw does not yet expose typed browser-profile dispatch, verified website account identity, or a direct browser-profile parameter for mission dispatch, so AgentOS passes selected profile/session context to eligible browser-capable agents.
 - `requires_approval` account access rules are intentionally blocked until approval dispatch exists. They are persisted as policy state but cannot run a task yet.
+- For high-risk social account missions, use the [social account mission recipe](docs/social-account-mission-recipe.md) to keep browser-profile context, OpenClaw plugin actions, and operator confirmations explicit.
 - Surface repair is preview-first. Apply only after reviewing the dry-run audit, backup path, affected config paths, and restore instructions.
 - `agentos doctor --deep` is the release-readiness diagnostic for Gateway protocol, native auth, scopes, required methods, config access, schema/patch support, channel status, model readiness, fallback count, and the last native failure.
 - Package release checks are covered by `pnpm check:release` and `pnpm smoke:agentos-package`; use the clean-install smoke checklist before publishing or announcing a release.
@@ -292,7 +293,7 @@ AgentOS is local-first and is intended to bind to loopback by default. Packaged 
 - Gateway event bridge for supported OpenClaw chat, tool, log, session, and approval events.
 - Gateway diagnostics, capability matrix, native auth repair, and control actions.
 - Local-first settings for gateway endpoint and workspace root.
-- Accounts page for OpenClaw browser-profile login targets, with AgentOS-side access rules and clear browser-profile dispatch limitations.
+- Accounts page for OpenClaw browser-profile login targets, with AgentOS-side access rules, clear browser-profile dispatch limitations, and a [social account mission recipe](docs/social-account-mission-recipe.md).
 - Install paths through the release installer and package manager.
 
 ### What is coming next

--- a/docs/social-account-mission-recipe.md
+++ b/docs/social-account-mission-recipe.md
@@ -1,0 +1,67 @@
+# Social Account Mission Recipe
+
+Use this recipe when an AgentOS workspace needs a human-reviewed mission that touches an owned social account, such as X/Twitter research, monitoring, drafts, replies, media review, direct messages, or post-publication checks.
+
+AgentOS stays the operator control layer. OpenClaw remains the runtime and plugin source of truth.
+
+## Current Support Matrix
+
+| Need | Current AgentOS path | Operator control |
+| --- | --- | --- |
+| Register an owned social login | Accounts page backed by an OpenClaw browser profile | AgentOS stores the service, domain, profile name, and stripped login URL only |
+| Let one agent use that account target | Account access rule with `use_browser_profile` | AgentOS passes account-target context before mission dispatch |
+| Require approval before account use | Account access rule with `requires_approval` | Persisted but blocked until approval dispatch exists |
+| Run an OpenClaw social plugin | Install and configure the plugin in OpenClaw | AgentOS can surface OpenClaw capabilities and transcript state, but plugin execution remains OpenClaw-owned |
+
+## Setup
+
+1. Run `agentos doctor --deep` and fix OpenClaw Gateway, auth, model, and browser-profile readiness before dispatching the mission.
+2. Open the Accounts page and connect the owned social account login through a reported OpenClaw browser profile.
+3. Keep the default account rule at `no_access`.
+4. Grant `use_browser_profile` only to the agent that should inspect or operate that account target.
+5. Keep `requires_approval` rules for future approval dispatch. Today they intentionally block mission launch.
+6. If the workflow needs structured X/Twitter actions, install TweetClaw in OpenClaw:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Configure any required TweetClaw or Xquik credential in the OpenClaw-approved configuration path. Do not paste keys, cookies, browser sessions, or tokens into AgentOS mission text.
+
+## Mission Template
+
+```text
+Use the selected AgentOS account target only for browser-profile selection.
+Do not ask for, print, store, or expose credentials, cookies, tokens, sessions, query parameters, or URL fragments.
+
+Start with read-only public checks.
+Allowed X/Twitter work: search tweets, search tweet replies, follower export, user lookup, media metadata review, monitor status review, and webhook status review.
+
+Before post tweets, post tweet replies, direct messages, media upload, monitor creation, webhook creation, or giveaway draws:
+1. Summarize the exact planned action.
+2. Show the account, target URL or handle, draft text, media, and expected side effect.
+3. Wait for explicit operator confirmation in this chat.
+
+If the browser tool cannot select the reported OpenClaw profile, stop and report that profile selection is not exposed for this dispatch path.
+If TweetClaw is not installed or configured in OpenClaw, stop and report the missing plugin capability.
+```
+
+## Review Checklist
+
+- Confirm the mission transcript shows the selected account target context.
+- Confirm the agent did not print login URLs with query strings, cookies, tokens, or API keys.
+- Confirm read-only collection happened before any proposed write action.
+- Confirm every public action had an explicit operator confirmation in chat.
+- Save useful source URLs, tweet IDs, handles, and review notes in workspace docs or deliverables.
+- Keep credentials, cookies, browser profile internals, direct-message contents, and private session details out of workspace files.
+
+## When To Stop
+
+Stop instead of dispatching when:
+
+- OpenClaw Gateway or browser-profile capability is unavailable.
+- The selected account rule is `no_access`.
+- The selected account rule is `requires_approval`.
+- The mission asks for account actions without a named account target.
+- The mission asks for unsupported plugin actions or missing TweetClaw capability.
+- The operator has not confirmed a public write action.


### PR DESCRIPTION
## Summary

- Adds a social account mission recipe for AgentOS workspaces that need operator-reviewed X/Twitter or other social-account actions.
- Documents the current supported path for OpenClaw browser profiles, the blocked `requires_approval` state, and where an optional TweetClaw OpenClaw plugin can provide structured X/Twitter actions.
- Links the recipe from the README compatibility notes and current Accounts feature list.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm check:release`
- `pnpm build`
- `git diff --check`
- Local Markdown link check for changed files
