### PR TITLE
feat(runtime): add Railway deployment stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.next
+.mission-control
+node_modules
+packages/agentos/bundle
+deliverables
+docs
+tests
+*.log
+.env
+.env.*
+!.env.example

--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -1,0 +1,65 @@
+FROM node:24-bookworm@sha256:3a09aa6354567619221ef6c45a5051b671f953f0a1924d1f819ffb236e520e6b AS agentos-build
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=/pnpm:$PATH
+
+RUN corepack enable
+
+WORKDIR /build
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN --mount=type=cache,id=agentos-pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+FROM ghcr.io/openclaw/openclaw:2026.6.11@sha256:3814fb1f62f9cfc5944de088c5817c68c88b5d721feebe36420b666a90a61ce7
+
+USER root
+
+RUN --mount=type=cache,id=agentos-bookworm-apt,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=agentos-bookworm-apt-lists,target=/var/lib/apt/lists,sharing=locked \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      chromium \
+      chromium-sandbox \
+      git \
+      gosu && \
+    rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock
+
+WORKDIR /agentos
+
+COPY --from=agentos-build --chown=node:node /build/.next/standalone ./
+COPY --from=agentos-build --chown=node:node /build/.next/static ./.next/static
+COPY --from=agentos-build --chown=node:node /build/public ./public
+COPY --chown=node:node scripts/railway-supervisor.mjs ./scripts/railway-supervisor.mjs
+COPY scripts/railway-entrypoint.sh ./scripts/railway-entrypoint.sh
+
+RUN chmod 0755 ./scripts/railway-entrypoint.sh && \
+    rm -rf /home/node/.openclaw /home/node/.config/openclaw && \
+    mkdir -p /home/node/.config /home/node/Documents/Shared && \
+    ln -s /data/agentos/mission-control /agentos/.mission-control && \
+    ln -s /data/openclaw /home/node/.openclaw && \
+    ln -s /data/openclaw-config /home/node/.config/openclaw && \
+    ln -s /data/workspaces /home/node/Documents/Shared/projects && \
+    chown -h node:node \
+      /agentos/.mission-control \
+      /home/node/.openclaw \
+      /home/node/.config/openclaw \
+      /home/node/Documents/Shared/projects
+
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    HOME=/home/node \
+    AGENTOS_PACKAGE_RUNTIME=1 \
+    AGENTOS_DEPLOYMENT_PLATFORM=railway \
+    AGENTOS_RUNTIME_DIR=/data/agentos \
+    OPENCLAW_STATE_DIR=/data/openclaw \
+    OPENCLAW_CONFIG_PATH=/data/openclaw/openclaw.json \
+    OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789 \
+    CHROME_BIN=/usr/bin/chromium
+
+EXPOSE 3000
+
+ENTRYPOINT ["tini", "-s", "--", "/agentos/scripts/railway-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ AgentOS is being built for that layer: the place where a person can turn individ
 
 ## Get started in 5 minutes
 
+### Deploy on Railway
+
+AgentOS includes a production-oriented Railway deployment path that runs AgentOS and the pinned OpenClaw Gateway together in one service. The deployment uses one persistent `/data` volume, keeps the Gateway on container loopback, initializes Instance Protection from the username and password supplied during deployment, and waits for both runtimes before passing Railway's healthcheck.
+
+The public one-click button requires a published Railway template code. Until the official template is published, use the exact template composer specification in [`docs/deploy-on-railway.md`](docs/deploy-on-railway.md). Do not deploy this repository as a stateless service: the `/data` volume and generated internal tokens are required.
+
+After the first deployment:
+
+1. Open the generated Railway domain and sign in with the initial admin credentials.
+2. Connect a model/provider from AgentOS Setup Center.
+3. Create the first workspace. AgentOS and OpenClaw state will persist across redeploys.
+
+The initial password only creates the account when no Instance Protection state exists. Changing that Railway variable later does not reset or replace the administrator account; use AgentOS account settings to change credentials. After the first successful sign-in, you may remove `AGENTOS_INITIAL_ADMIN_PASSWORD` from Railway because the protected account is already stored on the volume.
+
 ### Install
 
 macOS or Linux:
@@ -284,7 +298,7 @@ The Operations surface projects OpenClaw's cron runtime into an operator console
 
 ## Local-first security
 
-AgentOS currently targets trusted operator machines and local environments.
+AgentOS supports trusted operator machines and an explicitly configured hosted deployment.
 
 - The packaged launcher binds locally, generates an API token, starts AgentOS with authentication, and opens an authenticated local URL.
 - API routes are protected before route handlers run.
@@ -292,20 +306,20 @@ AgentOS currently targets trusted operator machines and local environments.
 - Remote Gateway URLs are blocked by default unless `AGENTOS_ALLOW_REMOTE_GATEWAY_URL=1` is explicitly enabled.
 - Sensitive values are redacted from diagnostics and compatibility reports.
 - Local auth and config files use owner-only permissions where applicable.
-- AgentOS should not be exposed publicly without an external network boundary, access policy, and monitoring.
+- Source and package installs should not be exposed publicly without an external network boundary, access policy, and monitoring. The Railway deployment uses Instance Protection, exact same-origin mutation checks, generated internal tokens, and a loopback-only OpenClaw Gateway as its minimum hosted boundary.
 
-For an intentionally remote operator deployment, configure a strong API token and an exact, comma-separated HTTPS origin allowlist:
+For a custom intentionally remote operator deployment, configure a strong API token and an exact, comma-separated HTTPS origin allowlist:
 
 ```bash
 AGENTOS_API_TOKEN=<secret>
 AGENTOS_TRUSTED_OPERATOR_ORIGINS=https://agentos.example.com
 ```
 
-Wildcards, HTTP origins, paths, query strings, and fragments are rejected. Keep AgentOS behind HTTPS and an authenticated reverse proxy, and preserve the public `Host`, `Origin`, `X-Forwarded-Host`, and `X-Forwarded-Proto` values. Origin allowlisting is an additional mutation boundary, not a substitute for authentication.
+Wildcards, HTTP origins, paths, query strings, and fragments are rejected. Keep AgentOS behind HTTPS and an authenticated reverse proxy, and preserve the public `Host`, `Origin`, `X-Forwarded-Host`, and `X-Forwarded-Proto` values. Origin allowlisting is an additional mutation boundary, not a substitute for authentication. Railway's generated `RAILWAY_PUBLIC_DOMAIN` is accepted automatically as one exact HTTPS operator origin; custom domains must still be listed explicitly.
 
 When Instance Protection is enabled, each trusted browser or mobile device can sign in with the configured username and password. The signed Instance Protection session authenticates subsequent API requests, so new devices do not need an `#agentos_token` bootstrap URL. The API token remains required while Instance Protection is disabled and for initial protected-instance setup.
 
-Several operations spawn local processes, inspect transcript files, or write to workspace directories. This makes the current release suitable for operator workstations and trusted hosts, not serverless-only deployment.
+Several operations spawn local processes, inspect transcript files, or write to workspace directories. This makes the current release suitable for operator workstations and persistent trusted hosts, including the documented Railway container, but not serverless-only deployment. Desktop-only actions such as revealing a host file in Finder do not become remote desktop features on Railway.
 
 ## Compatibility
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,10 +19,12 @@ AgentOS is pre-1.0. Security fixes are prepared against the current main branch 
 
 ## Operational Guidance
 
-AgentOS is intended to run as the local operator interface for OpenClaw. Keep it bound to `127.0.0.1` unless you have added your own network controls, and use the authenticated URL printed by the `agentos` launcher for packaged installs.
+AgentOS defaults to a local operator interface for OpenClaw. Keep it bound to `127.0.0.1` for source and package installs unless you have added intentional hosted access controls, and use the authenticated URL printed by the `agentos` launcher for packaged installs.
 
 Packaged AgentOS generates a local API token, protects API routes centrally, and stores sensitive runtime auth/config files with owner-only permissions where applicable. Remote OpenClaw Gateway URLs are blocked by default unless explicitly allowed with `AGENTOS_ALLOW_REMOTE_GATEWAY_URL=1`. Do not expose AgentOS publicly without your own network access controls, authentication policy, and monitoring.
 
 Remote mutation access is disabled by default. An operator may explicitly allow exact HTTPS origins with the comma-separated `AGENTOS_TRUSTED_OPERATOR_ORIGINS` environment variable. This opt-in still requires AgentOS API authentication; it rejects wildcards, HTTP origins, paths, queries, fragments, missing Origin headers, and mismatched forwarded hosts. Deploy remote access only behind HTTPS and an authenticated reverse proxy that preserves trustworthy public host and protocol headers.
 
 When Instance Protection is enabled, its signed, HttpOnly, SameSite session cookie is accepted as API authentication for that browser. Public Instance Protection status, login, and logout endpoints do not require the machine API token; login remains password-protected, rate-limited, and subject to the localhost or trusted-origin mutation guard. This lets a new trusted browser authenticate with operator credentials without distributing the machine API token. When Instance Protection is disabled, the API token remains required for protected API access.
+
+The documented Railway deployment is an intentional hosted mode. It requires generated internal API and Gateway tokens, initializes Instance Protection before serving operator traffic, accepts only the exact Railway HTTPS domain automatically, keeps OpenClaw Gateway bound to container loopback, and stores AgentOS, OpenClaw, and workspace state on a persistent volume. The public `/api/health` endpoint returns only `ok` or `starting` and no runtime details. Additional custom domains require an explicit `AGENTOS_TRUSTED_OPERATOR_ORIGINS` entry.

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1_500);
+
+  try {
+    const response = await fetch("http://127.0.0.1:18789/readyz", {
+      cache: "no-store",
+      signal: controller.signal
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { status: "starting" },
+        { status: 503, headers: { "Cache-Control": "no-store" } }
+      );
+    }
+
+    return NextResponse.json(
+      { status: "ok" },
+      { headers: { "Cache-Control": "no-store" } }
+    );
+  } catch {
+    return NextResponse.json(
+      { status: "starting" },
+      { status: 503, headers: { "Cache-Control": "no-store" } }
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/components/mission-control/mission-control-dialog-shell.tsx
+++ b/components/mission-control/mission-control-dialog-shell.tsx
@@ -28,6 +28,9 @@ type MissionControlDialogShellProps = {
   children: ReactNode;
   bodyClassName?: string;
   contentClassName?: string;
+  headerClassName?: string;
+  footerClassName?: string;
+  footerInnerClassName?: string;
   variant?: "default" | "worker-profile";
   disableOutsideDismiss?: boolean;
 };
@@ -46,6 +49,9 @@ export function MissionControlDialogShell({
   children,
   bodyClassName,
   contentClassName,
+  headerClassName,
+  footerClassName,
+  footerInnerClassName,
   variant = "default",
   disableOutsideDismiss = false
 }: MissionControlDialogShellProps) {
@@ -76,7 +82,8 @@ export function MissionControlDialogShell({
           className={cn(
             "relative space-y-0 border-b px-6 pb-2 pt-3",
             isWorkerProfile && "overflow-hidden px-5 pb-3.5 pt-4 sm:px-7",
-            isLight ? "border-[#e7dfd4]" : "border-white/[0.06]"
+            isLight ? "border-[#e7dfd4]" : "border-white/[0.06]",
+            headerClassName
           )}
         >
           {isWorkerProfile ? (
@@ -125,8 +132,8 @@ export function MissionControlDialogShell({
         <div className={cn("min-h-0 overflow-y-auto px-4 py-3", isWorkerProfile && "bg-[linear-gradient(180deg,rgba(255,255,255,0.018),transparent_24%)]", bodyClassName)}>{children}</div>
 
         {footer ? (
-          <DialogFooter className={cn("gap-0 border-t px-4 py-1.5", isWorkerProfile && "px-5 py-2 sm:px-7", isLight ? "border-[#e7dfd4]" : "border-white/[0.07]")}>
-            <div className={cn("flex w-full items-center justify-between rounded-[8px] px-1.5 py-1", isWorkerProfile && "rounded-xl px-1.5 py-1", isLight ? "bg-white/45" : "bg-white/[0.018]")}>
+          <DialogFooter className={cn("gap-0 border-t px-4 py-1.5", isWorkerProfile && "px-5 py-2 sm:px-7", isLight ? "border-[#e7dfd4]" : "border-white/[0.07]", footerClassName)}>
+            <div className={cn("flex w-full items-center justify-between rounded-[8px] px-1.5 py-1", isWorkerProfile && "rounded-xl px-1.5 py-1", isLight ? "bg-white/45" : "bg-white/[0.018]", footerInnerClassName)}>
               {footer}
             </div>
           </DialogFooter>

--- a/components/mission-control/mission-control-shell.tsx
+++ b/components/mission-control/mission-control-shell.tsx
@@ -4256,7 +4256,6 @@ export function MissionControlShell({
           >
             <Menu className="h-5 w-5" />
           </button>
-          <MissionControlCanvasTitlePill surfaceTheme={surfaceTheme} />
           <button
             type="button"
             aria-label={isInspectorOpen ? "Close inspector" : "Open inspector"}

--- a/components/mission-control/mission-control-shell.tsx
+++ b/components/mission-control/mission-control-shell.tsx
@@ -3871,6 +3871,7 @@ export function MissionControlShell({
           <MissionSidebar
             snapshot={uiSnapshot}
             surfaceTheme={surfaceTheme}
+            onToggleTheme={() => setSurfaceTheme((current) => (current === "light" ? "dark" : "light"))}
             activeWorkspaceId={activeWorkspaceId}
             requestedAgentAction={agentActionRequest}
             connectionState={connectionState}
@@ -3989,6 +3990,7 @@ export function MissionControlShell({
           <MissionSidebar
             snapshot={uiSnapshot}
             surfaceTheme={surfaceTheme}
+            onToggleTheme={() => setSurfaceTheme((current) => (current === "light" ? "dark" : "light"))}
             activeWorkspaceId={activeWorkspaceId}
             requestedAgentAction={agentActionRequest}
             connectionState={connectionState}
@@ -4315,6 +4317,7 @@ export function MissionControlShell({
           <MissionSidebar
             snapshot={uiSnapshot}
             surfaceTheme={surfaceTheme}
+            onToggleTheme={() => setSurfaceTheme((current) => (current === "light" ? "dark" : "light"))}
             activeWorkspaceId={activeWorkspaceId}
             requestedAgentAction={agentActionRequest}
             connectionState={connectionState}
@@ -4387,6 +4390,7 @@ export function MissionControlShell({
           <MissionSidebar
             snapshot={uiSnapshot}
             surfaceTheme={surfaceTheme}
+            onToggleTheme={() => setSurfaceTheme((current) => (current === "light" ? "dark" : "light"))}
             activeWorkspaceId={activeWorkspaceId}
             requestedAgentAction={agentActionRequest}
             connectionState={connectionState}

--- a/components/mission-control/mission-control-shell.tsx
+++ b/components/mission-control/mission-control-shell.tsx
@@ -3957,21 +3957,6 @@ export function MissionControlShell({
               <p className="truncate text-sm font-semibold">Settings</p>
               <p className={cn("truncate text-[0.68rem]", surfaceTheme === "light" ? "text-[#7a6658]" : "text-slate-400")}>System control center</p>
             </div>
-            <span
-              className={cn(
-                "inline-flex h-11 items-center gap-2 rounded-xl border px-3 text-[0.65rem] font-semibold uppercase tracking-[0.12em]",
-                connectionState === "live"
-                  ? surfaceTheme === "light"
-                    ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-                    : "border-emerald-300/20 bg-emerald-300/10 text-emerald-100"
-                  : surfaceTheme === "light"
-                    ? "border-amber-200 bg-amber-50 text-amber-700"
-                    : "border-amber-300/20 bg-amber-300/10 text-amber-100"
-              )}
-            >
-              <span className={cn("h-2 w-2 rounded-full", connectionState === "live" ? "bg-emerald-500" : "bg-amber-400")} />
-              <span className="sr-only sm:not-sr-only">{connectionState === "live" ? "Online" : connectionState === "retrying" ? "Retrying" : "Connecting"}</span>
-            </span>
           </div>
         ) : null}
 

--- a/components/mission-control/sidebar.tsx
+++ b/components/mission-control/sidebar.tsx
@@ -24,11 +24,13 @@ import {
   LifeBuoy,
   LockKeyhole,
   LogOut,
+  Moon,
   Pencil,
   Plug,
   Plus,
   Settings2,
   ShieldCheck,
+  SunMedium,
   Trash2,
   UserRound
 } from "lucide-react";
@@ -151,6 +153,7 @@ type MissionSidebarProps = {
   };
   onExpandCollapsed?: () => void;
   onToggleCollapsed: () => void;
+  onToggleTheme: () => void;
   onSelectWorkspace: (workspaceId: string | null) => void;
   onRefresh: () => Promise<void>;
   onRunModelRefresh: () => void;
@@ -225,6 +228,7 @@ export function MissionSidebar({
   sidebarPinned = false,
   onExpandCollapsed,
   onToggleCollapsed,
+  onToggleTheme,
   onSelectWorkspace,
   onRefresh,
   onOpenCreateAgent,
@@ -584,9 +588,11 @@ export function MissionSidebar({
             <SidebarUserMenu
               snapshot={snapshot}
               activeWorkspaceId={activeWorkspaceId}
+              surfaceTheme={surfaceTheme}
               operatorProfile={operatorProfile}
               onProfileSaved={setOperatorProfile}
               onRefresh={onRefresh}
+              onToggleTheme={onToggleTheme}
             />
           </div>
         </aside>
@@ -2090,15 +2096,19 @@ function SidebarNavItem({
 function SidebarUserMenu({
   snapshot,
   activeWorkspaceId,
+  surfaceTheme,
   operatorProfile,
   onProfileSaved,
-  onRefresh
+  onRefresh,
+  onToggleTheme
 }: {
   snapshot: MissionControlSnapshot;
   activeWorkspaceId: string | null;
+  surfaceTheme: "dark" | "light";
   operatorProfile: OperatorProfileSummary;
   onProfileSaved: (profile: OperatorProfileSummary) => void;
   onRefresh: () => Promise<void>;
+  onToggleTheme: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
@@ -2174,6 +2184,7 @@ function SidebarUserMenu({
               }}
             />
             <SidebarUserMenuLink href="/settings" icon={Settings2} label="Settings" onNavigate={() => setOpen(false)} />
+            <SidebarThemeMenuAction surfaceTheme={surfaceTheme} onToggle={onToggleTheme} />
             <SidebarUserMenuAction
               icon={ShieldCheck}
               label="Login & Protection"
@@ -2246,6 +2257,46 @@ function SidebarUserMenu({
       />
       <InstanceProtectionDialog open={protectionOpen} onOpenChange={setProtectionOpen} />
     </>
+  );
+}
+
+function SidebarThemeMenuAction({
+  surfaceTheme,
+  onToggle
+}: {
+  surfaceTheme: "dark" | "light";
+  onToggle: () => void;
+}) {
+  const isDark = surfaceTheme === "dark";
+  const Icon = isDark ? Moon : SunMedium;
+
+  return (
+    <button
+      type="button"
+      role="menuitemcheckbox"
+      aria-checked={isDark}
+      aria-label={`Appearance: ${isDark ? "dark" : "light"} theme. Switch to ${isDark ? "light" : "dark"} theme`}
+      onClick={onToggle}
+      className="flex h-10 w-full items-center gap-3 rounded-lg px-2.5 text-left text-sm font-medium text-foreground outline-none transition-colors hover:bg-accent focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring/50"
+    >
+      <Icon className="h-[18px] w-[18px] shrink-0 text-muted-foreground" />
+      <span>Appearance</span>
+      <span className="ml-auto text-xs font-medium text-muted-foreground">{isDark ? "Dark" : "Light"}</span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "relative h-5 w-9 shrink-0 rounded-full border transition-colors",
+          isDark ? "border-primary/40 bg-primary/80" : "border-border bg-muted"
+        )}
+      >
+        <span
+          className={cn(
+            "absolute top-0.5 h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform",
+            isDark ? "translate-x-[17px]" : "translate-x-0.5"
+          )}
+        />
+      </span>
+    </button>
   );
 }
 

--- a/components/mission-control/workspace-wizard/workspace-wizard-dialog.tsx
+++ b/components/mission-control/workspace-wizard/workspace-wizard-dialog.tsx
@@ -320,15 +320,16 @@ export function WorkspaceWizardDialog({
       }
       icon={Bot}
       chips={headerBadges.map((badge) => (
-        <MissionControlDialogChip
-          key={badge.id}
-          tone={badge.tone === "success" ? "emerald" : badge.tone === "warning" ? "amber" : "muted"}
-        >
-          {badge.label}
-        </MissionControlDialogChip>
+        <span key={badge.id} className="hidden md:contents">
+          <MissionControlDialogChip
+            tone={badge.tone === "success" ? "emerald" : badge.tone === "warning" ? "amber" : "muted"}
+          >
+            {badge.label}
+          </MissionControlDialogChip>
+        </span>
       ))}
       headerActions={
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="hidden flex-wrap items-center gap-2 md:flex">
           {!isEditingWorkspace ? (
             <div className="inline-flex rounded-[8px] border border-white/10 bg-white/[0.04] p-0.5">
               {(["basic", "advanced"] as WorkspaceWizardMode[]).map((mode) => (
@@ -371,9 +372,14 @@ export function WorkspaceWizardDialog({
           ) : null}
         </div>
       }
+      contentClassName="h-[100dvh] max-h-[100dvh] w-screen rounded-none border-x-0 md:h-[min(calc(100vh-72px),760px)] md:max-h-[calc(100vh-72px)] md:w-[min(90vw,1060px)] md:rounded-2xl md:border-x"
+      headerClassName="px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top))] md:px-6 md:pb-2 md:pt-3"
       bodyClassName="p-0 overflow-hidden"
+      footerClassName="px-3 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 md:px-4 md:py-1.5"
+      footerInnerClassName="p-0 md:px-1.5 md:py-1"
       footer={
         <WorkspaceWizardFooterActions
+          surfaceTheme={surfaceTheme}
           wizardMode={wizard.mode}
           basicStep={basicStep}
           isEditingWorkspace={isEditingWorkspace}
@@ -419,32 +425,49 @@ export function WorkspaceWizardDialog({
                         />
                       ) : null}
 
-                      {wizard.isPlanLoading ? <LoadingGreeting surfaceTheme={effectiveSurfaceTheme} /> : <BasicGreeting surfaceTheme={effectiveSurfaceTheme} />}
+                      <div className="md:hidden">
+                        <MobileWorkspaceCreateForm
+                          surfaceTheme={effectiveSurfaceTheme}
+                          name={wizard.basicDraft.name}
+                          goal={wizard.basicDraft.goal}
+                          source={wizard.basicDraft.source}
+                          template={wizard.basicTemplate}
+                          disabled={isArchitectBusy}
+                          onNameChange={wizard.setBasicName}
+                          onGoalChange={wizard.setBasicGoal}
+                          onSourceChange={wizard.setBasicSource}
+                          onTemplateChange={wizard.setBasicTemplate}
+                        />
+                      </div>
 
-                      <WorkspaceWizardBasicFlow
-                        surfaceTheme={effectiveSurfaceTheme}
-                        step={basicStep}
-                        isBusy={isArchitectBusy}
-                        basicDraft={wizard.basicDraft}
-                        basicTemplate={wizard.basicTemplate}
-                        basicTeamPreset={wizard.basicTeamPreset}
-                        basicModelProfile={wizard.basicModelProfile}
-                        basicRules={wizard.basicRules}
-                        basicPreset={wizard.basicPreset}
-                        resolvedName={resolvedName}
-                        resolvedTemplate={resolvedTemplate}
-                        sourceAnalysis={wizard.sourceAnalysis}
-                        workspacePath={workspacePath}
-                        onStepChange={setBasicStep}
-                        onBasicNameChange={wizard.setBasicName}
-                        onBasicGoalChange={wizard.setBasicGoal}
-                        onBasicSourceChange={wizard.setBasicSource}
-                        onBasicTemplateChange={wizard.setBasicTemplate}
-                        onBasicTeamPresetChange={wizard.setBasicTeamPreset}
-                        onBasicModelProfileChange={wizard.setBasicModelProfile}
-                        onBasicPresetChange={wizard.setBasicPreset}
-                        onBasicRuleToggle={wizard.toggleBasicRule}
-                      />
+                      <div className="hidden md:block">
+                        {wizard.isPlanLoading ? <LoadingGreeting surfaceTheme={effectiveSurfaceTheme} /> : <BasicGreeting surfaceTheme={effectiveSurfaceTheme} />}
+
+                        <WorkspaceWizardBasicFlow
+                          surfaceTheme={effectiveSurfaceTheme}
+                          step={basicStep}
+                          isBusy={isArchitectBusy}
+                          basicDraft={wizard.basicDraft}
+                          basicTemplate={wizard.basicTemplate}
+                          basicTeamPreset={wizard.basicTeamPreset}
+                          basicModelProfile={wizard.basicModelProfile}
+                          basicRules={wizard.basicRules}
+                          basicPreset={wizard.basicPreset}
+                          resolvedName={resolvedName}
+                          resolvedTemplate={resolvedTemplate}
+                          sourceAnalysis={wizard.sourceAnalysis}
+                          workspacePath={workspacePath}
+                          onStepChange={setBasicStep}
+                          onBasicNameChange={wizard.setBasicName}
+                          onBasicGoalChange={wizard.setBasicGoal}
+                          onBasicSourceChange={wizard.setBasicSource}
+                          onBasicTemplateChange={wizard.setBasicTemplate}
+                          onBasicTeamPresetChange={wizard.setBasicTeamPreset}
+                          onBasicModelProfileChange={wizard.setBasicModelProfile}
+                          onBasicPresetChange={wizard.setBasicPreset}
+                          onBasicRuleToggle={wizard.toggleBasicRule}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -723,6 +746,7 @@ export function WorkspaceWizardDialog({
 type WorkspaceWizardController = ReturnType<typeof useWorkspaceWizardDraft>;
 
 function WorkspaceWizardFooterActions({
+  surfaceTheme,
   wizardMode,
   basicStep,
   isEditingWorkspace,
@@ -735,6 +759,7 @@ function WorkspaceWizardFooterActions({
   onBasicStepBack,
   onBasicStepPrimary
 }: {
+  surfaceTheme: SurfaceTheme;
   wizardMode: WorkspaceWizardMode;
   basicStep: WorkspaceCreateStep;
   isEditingWorkspace: boolean;
@@ -758,9 +783,34 @@ function WorkspaceWizardFooterActions({
 
   return (
     <>
-      <p className="min-w-0 truncate pr-3 text-[11px] text-slate-400">{statusLabel}</p>
+      {!isEditingWorkspace && wizardMode === "basic" ? (
+        <div className="flex w-full items-center gap-2 md:hidden">
+          <Button
+            variant="secondary"
+            className={cn(missionControlDialogButtonClassName("secondary", surfaceTheme), "h-11 flex-1 rounded-xl text-[13px]")}
+            onClick={() => void wizard.switchMode("advanced")}
+            disabled={wizard.isCreating || wizard.isSending || wizard.isPlanLoading}
+          >
+            Advanced
+          </Button>
+          <Button
+            className={cn(missionControlDialogButtonClassName("primary", surfaceTheme), "h-11 flex-[1.6] rounded-xl text-[13px]")}
+            onClick={() => void onCreateWorkspace()}
+            disabled={!hasDraftToCreate || wizard.isCreating || wizard.isSending || wizard.isPlanLoading}
+          >
+            {wizard.isCreating ? (
+              <LoaderCircle className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="mr-1.5 h-4 w-4" />
+            )}
+            {wizard.isCreating ? "Creating..." : "Create workspace"}
+          </Button>
+        </div>
+      ) : null}
 
-      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+      <p className={cn("min-w-0 truncate pr-3 text-[11px] text-slate-400", !isEditingWorkspace && wizardMode === "basic" && "hidden md:block")}>{statusLabel}</p>
+
+      <div className={cn("flex shrink-0 flex-wrap items-center justify-end gap-2", !isEditingWorkspace && wizardMode === "basic" && "hidden md:flex")}>
         <Button
           variant="secondary"
           size="sm"
@@ -873,6 +923,125 @@ function WorkspaceWizardFooterActions({
         )}
       </div>
     </>
+  );
+}
+
+function MobileWorkspaceCreateForm({
+  surfaceTheme,
+  name,
+  goal,
+  source,
+  template,
+  disabled,
+  onNameChange,
+  onGoalChange,
+  onSourceChange,
+  onTemplateChange
+}: {
+  surfaceTheme: SurfaceTheme;
+  name: string;
+  goal: string;
+  source: string;
+  template: WorkspaceTemplate;
+  disabled: boolean;
+  onNameChange: (value: string) => void;
+  onGoalChange: (value: string) => void;
+  onSourceChange: (value: string) => void;
+  onTemplateChange: (value: WorkspaceTemplate) => void;
+}) {
+  const isLight = surfaceTheme === "light";
+  const controlClassName = cn(
+    "h-12 rounded-xl text-[16px] shadow-none",
+    isLight
+      ? "border-[#e1d7cc] bg-white text-[#1c1916] placeholder:text-[#9b948c] focus-visible:ring-[#b8ada1]"
+      : "border-white/10 bg-[rgba(4,8,15,0.72)] text-slate-100 placeholder:text-slate-500 focus-visible:ring-cyan-300/60"
+  );
+
+  return (
+    <section className="mx-auto w-full max-w-lg pb-2">
+      <div className="mb-5">
+        <p className={cn("text-[11px] font-medium uppercase tracking-[0.2em]", isLight ? "text-[#8b7262]" : "text-cyan-200/70")}>
+          Quick setup
+        </p>
+        <h2 className={cn("mt-2 text-[25px] font-semibold tracking-[-0.035em]", isLight ? "text-[#201a16]" : "text-white")}>
+          What are you building?
+        </h2>
+        <p className={cn("mt-2 text-[14px] leading-6", isLight ? "text-[#766e64]" : "text-slate-400")}>
+          Add the essentials now. AgentOS will use sensible defaults for the team, model, and workspace files.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <label className="block space-y-1.5" htmlFor="mobile-workspace-name">
+          <span className={cn("text-[12px] font-medium", isLight ? "text-[#5f554d]" : "text-slate-300")}>Workspace name</span>
+          <Input
+            id="mobile-workspace-name"
+            value={name}
+            onChange={(event) => onNameChange(event.target.value)}
+            placeholder="e.g. Product launch"
+            disabled={disabled}
+            autoComplete="off"
+            className={controlClassName}
+          />
+        </label>
+
+        <label className="block space-y-1.5" htmlFor="mobile-workspace-goal">
+          <span className={cn("text-[12px] font-medium", isLight ? "text-[#5f554d]" : "text-slate-300")}>Main goal</span>
+          <Textarea
+            id="mobile-workspace-goal"
+            value={goal}
+            onChange={(event) => onGoalChange(event.target.value)}
+            placeholder="What should this workspace help you accomplish?"
+            disabled={disabled}
+            className={cn(controlClassName, "min-h-[112px] resize-none py-3 leading-6")}
+          />
+        </label>
+
+        <label className="block space-y-1.5" htmlFor="mobile-workspace-source">
+          <span className={cn("flex items-center gap-1.5 text-[12px] font-medium", isLight ? "text-[#5f554d]" : "text-slate-300")}>
+            Starting point
+            <span className={cn("font-normal", isLight ? "text-[#9a8f84]" : "text-slate-500")}>(optional)</span>
+          </span>
+          <Input
+            id="mobile-workspace-source"
+            value={source}
+            onChange={(event) => onSourceChange(event.target.value)}
+            placeholder="Repository, website, or folder path"
+            disabled={disabled}
+            autoCapitalize="none"
+            autoCorrect="off"
+            className={controlClassName}
+          />
+        </label>
+
+        <label className="block space-y-1.5" htmlFor="mobile-workspace-template">
+          <span className={cn("text-[12px] font-medium", isLight ? "text-[#5f554d]" : "text-slate-300")}>Workspace type</span>
+          <select
+            id="mobile-workspace-template"
+            value={template}
+            onChange={(event) => onTemplateChange(event.target.value as WorkspaceTemplate)}
+            disabled={disabled}
+            className={cn(controlClassName, "w-full appearance-none px-3 outline-none")}
+          >
+            {WORKSPACE_TEMPLATE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className={cn("mt-5 flex items-center gap-3 rounded-2xl border px-3.5 py-3", isLight ? "border-[#e7ddd2] bg-[#faf6f1]" : "border-white/10 bg-white/[0.035]")}>
+        <span className={cn("flex h-9 w-9 shrink-0 items-center justify-center rounded-xl", isLight ? "bg-white text-[#8a6547]" : "bg-violet-400/10 text-violet-200")}>
+          <Bot className="h-4 w-4" />
+        </span>
+        <div className="min-w-0">
+          <p className={cn("text-[12px] font-medium", isLight ? "text-[#3e342c]" : "text-slate-200")}>Ready with recommended defaults</p>
+          <p className={cn("mt-0.5 truncate text-[11px]", isLight ? "text-[#84786d]" : "text-slate-500")}>Core team · Balanced model · Standard setup</p>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/components/operations/operations-shell.tsx
+++ b/components/operations/operations-shell.tsx
@@ -355,6 +355,7 @@ export function OperationsShell({
         <MissionSidebar
           snapshot={snapshot}
           surfaceTheme={surfaceTheme}
+          onToggleTheme={() => setSurfaceTheme((current) => (current === "light" ? "dark" : "light"))}
           activeWorkspaceId={activeWorkspaceId}
           pendingCreatedAgents={visiblePendingCreatedAgents}
           requestedAgentAction={null}
@@ -418,6 +419,7 @@ export function OperationsShell({
         <MissionSidebar
           snapshot={snapshot}
           surfaceTheme={surfaceTheme}
+          onToggleTheme={() => setSurfaceTheme((current) => (current === "light" ? "dark" : "light"))}
           activeWorkspaceId={activeWorkspaceId}
           pendingCreatedAgents={visiblePendingCreatedAgents}
           requestedAgentAction={null}

--- a/components/operations/operations-ui.tsx
+++ b/components/operations/operations-ui.tsx
@@ -84,18 +84,17 @@ export function OperationsTopBar({
       <span className="hidden font-mono text-muted-foreground/80 sm:inline">
         v{version}
       </span>
-      <span
-        className={cn(
-          "inline-flex items-center gap-1.5 rounded-full border tracking-[0.16em]",
-          compact ? "h-11 px-3" : "px-2.5 py-1",
-          online ? toneStyles.success : toneStyles.warning
-        )}
-      >
+      {!compact ? (
         <span
-          className={cn("h-1.5 w-1.5 rounded-full", online ? dotStyles.success : dotStyles.warning)}
-        />
-        <span className={compact ? "sr-only" : undefined}>{label}</span>
-      </span>
+          className={cn(
+            "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 tracking-[0.16em]",
+            online ? toneStyles.success : toneStyles.warning
+          )}
+        >
+          <span className={cn("h-1.5 w-1.5 rounded-full", online ? dotStyles.success : dotStyles.warning)} />
+          <span>{label}</span>
+        </span>
+      ) : null}
       <RuntimeIssueIndicator
         snapshot={snapshot}
         surfaceTheme={surfaceTheme}

--- a/docs/deploy-on-railway.md
+++ b/docs/deploy-on-railway.md
@@ -1,0 +1,101 @@
+# Deploy AgentOS on Railway
+
+The Railway deployment runs AgentOS and OpenClaw `2026.6.11` in one service. OpenClaw remains the runtime and source of truth; AgentOS connects to its native Gateway over `ws://127.0.0.1:18789`. Only AgentOS is exposed through Railway's HTTPS domain.
+
+## What the template creates
+
+- One GitHub-backed service built with `Dockerfile.railway`.
+- One public Railway HTTPS domain for AgentOS.
+- One persistent volume mounted at `/data`.
+- One generated AgentOS machine API token.
+- One generated OpenClaw Gateway token.
+- One initial administrator username and user-supplied password.
+- A `/api/health` deployment healthcheck.
+
+The single-service design is intentional. It keeps the Gateway private, avoids cross-service credential and state synchronization, and matches AgentOS's current local-Gateway architecture. Railway services with volumes should use one replica; horizontal replicas would not share a single writable OpenClaw runtime safely.
+
+## Template composer specification
+
+Create the template from the `https://github.com/SapienXai/AgentOS` repository and use the default branch. Configure the service as follows.
+
+### Service
+
+- Name: `AgentOS`
+- Source: `https://github.com/SapienXai/AgentOS`
+- Builder: Dockerfile (the repository's `railway.json` selects `Dockerfile.railway`)
+- Public networking: enabled, generate a domain
+- Healthcheck path: `/api/health`
+- Healthcheck timeout: `300` seconds
+- Restart policy: `ON_FAILURE`, maximum `10` retries
+- Replicas: `1`
+
+### Volume
+
+Attach one volume to the AgentOS service with mount path:
+
+```text
+/data
+```
+
+The volume contains:
+
+- `/data/agentos`: Instance Protection and AgentOS operator state;
+- `/data/openclaw` and `/data/openclaw-config`: OpenClaw configuration, device identity, credentials, sessions, and logs;
+- `/data/workspaces`: AgentOS-created workspaces.
+
+Do not use a pre-deploy command for initialization. Railway mounts volumes only when the service starts, and the container entrypoint performs first-run initialization safely at runtime.
+
+### Variables
+
+| Variable | Template value | User-facing | Purpose |
+| --- | --- | --- | --- |
+| `AGENTOS_INITIAL_ADMIN_USERNAME` | `admin` | Editable | Initial Instance Protection username. |
+| `AGENTOS_INITIAL_ADMIN_PASSWORD` | No default; required input | Required | Initial Instance Protection password. Use at least 12 characters. |
+| `AGENTOS_API_TOKEN` | `${{secret(64)}}` | Hidden/generated | Internal machine API authentication and recovery boundary. |
+| `OPENCLAW_GATEWAY_TOKEN` | `${{secret(64)}}` | Hidden/generated | Authentication for the loopback OpenClaw Gateway. |
+| `RAILWAY_RUN_UID` | `0` | Hidden | Lets the entrypoint repair volume ownership before dropping to the non-root `node` user. |
+| `RAILWAY_SHM_SIZE_BYTES` | `268435456` | Hidden | Provides Chromium with a larger shared-memory area. |
+
+Do not add `AGENTOS_TRUSTED_OPERATOR_ORIGINS` for the generated Railway domain. AgentOS derives the exact HTTPS origin from `RAILWAY_PUBLIC_DOMAIN`. If a custom domain is added later, set `AGENTOS_TRUSTED_OPERATOR_ORIGINS=https://agentos.example.com` as an additional exact origin.
+
+## First deployment
+
+1. Enter the initial administrator username and password in the template form.
+2. Deploy the template.
+3. Wait until `/api/health` passes. The startup supervisor starts OpenClaw first and starts AgentOS only after the Gateway readiness endpoint responds.
+4. Open the generated HTTPS domain and sign in.
+5. Remove `AGENTOS_INITIAL_ADMIN_PASSWORD` from the Railway service variables after confirming the first sign-in. The account remains on the persistent volume.
+6. Connect a real model/provider in Setup Center.
+7. Create a workspace and run the compatibility diagnostics before assigning production work.
+
+The bootstrap password is used only when `/data/agentos/instance-protection.json` does not exist. It is removed from the long-running AgentOS process after bootstrap and is never passed to OpenClaw, but Railway retains the service variable until the operator removes it. Redeploying or changing the variable does not replace the account. Change credentials from AgentOS. If recovery is required, use a Railway shell to run the documented Instance Protection reset deliberately; deleting the volume is not an account-reset mechanism because it also destroys OpenClaw and workspace state.
+
+## Runtime and security behavior
+
+- The container starts as root only long enough to prepare the root-owned Railway volume, then runs both AgentOS and OpenClaw as the non-root `node` user.
+- The initial admin password is removed from the long-running AgentOS process after bootstrap and is never passed to the OpenClaw process.
+- OpenClaw listens only on container loopback. It has no Railway public port or domain.
+- Browser sessions authenticate with the same username and password on every trusted browser; session cookies remain browser-specific.
+- Login is rate-limited. Mutation requests require an authenticated session and an exact same-origin HTTPS request.
+- Chromium is included for OpenClaw browser automation. Interactive desktop actions and host Finder/Terminal integration are not available in a headless Railway container.
+- The health endpoint intentionally reveals no version, token, path, account, or Gateway detail.
+
+## Persistence and operations
+
+Back up the Railway volume before risky upgrades. A service with an attached volume has brief redeploy downtime, and Railway cannot run multiple replicas against this single-runtime layout. Monitor volume capacity because a full volume can prevent OpenClaw and AgentOS from writing state.
+
+OpenClaw is pinned in `Dockerfile.railway`. Upgrade it only together with AgentOS compatibility checks and update the pin, recommended version, and deployment documentation in the same change.
+
+## Publishing the one-click button
+
+Railway assigns the template code only after the template is created in the Railway workspace. Once created and test-deployed:
+
+1. Publish the template.
+2. Copy its template code from Railway.
+3. Add Railway's official button to the README, replacing `<TEMPLATE_CODE>`:
+
+```md
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/<TEMPLATE_CODE>?utm_medium=integration&utm_source=template&utm_campaign=agentos)
+```
+
+Do not merge a placeholder template code. Verify the button in a signed-out browser and complete a clean deployment before calling the one-click flow available.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,14 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return;
+  }
+
+  const { bootstrapInitialInstanceProtection } = await import(
+    "@/lib/security/initial-instance-bootstrap"
+  );
+  const result = await bootstrapInitialInstanceProtection();
+
+  if (result.status === "created") {
+    console.info("AgentOS Instance Protection was initialized for this deployment.");
+  }
+}

--- a/lib/security/initial-instance-bootstrap.ts
+++ b/lib/security/initial-instance-bootstrap.ts
@@ -1,0 +1,35 @@
+import {
+  enableInstanceProtection,
+  readInstanceProtectionState
+} from "@/lib/security/instance-protection";
+
+export const AGENTOS_INITIAL_ADMIN_USERNAME_ENV = "AGENTOS_INITIAL_ADMIN_USERNAME";
+export const AGENTOS_INITIAL_ADMIN_PASSWORD_ENV = "AGENTOS_INITIAL_ADMIN_PASSWORD";
+
+export type InitialInstanceBootstrapResult =
+  | { status: "not-configured" }
+  | { status: "already-configured" }
+  | { status: "created" };
+
+export async function bootstrapInitialInstanceProtection(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<InitialInstanceBootstrapResult> {
+  const password = env[AGENTOS_INITIAL_ADMIN_PASSWORD_ENV];
+
+  if (!password) {
+    return { status: "not-configured" };
+  }
+
+  try {
+    if (await readInstanceProtectionState(env)) {
+      return { status: "already-configured" };
+    }
+
+    const username = env[AGENTOS_INITIAL_ADMIN_USERNAME_ENV]?.trim() || "admin";
+    await enableInstanceProtection({ username, password }, env);
+    return { status: "created" };
+  } finally {
+    // Keep the bootstrap credential out of the long-running Next.js process.
+    delete env[AGENTOS_INITIAL_ADMIN_PASSWORD_ENV];
+  }
+}

--- a/lib/security/local-operator.ts
+++ b/lib/security/local-operator.ts
@@ -11,6 +11,7 @@ export type LocalOperatorGuardDecision =
 
 export const SAFE_API_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 export const AGENTOS_TRUSTED_OPERATOR_ORIGINS_ENV = "AGENTOS_TRUSTED_OPERATOR_ORIGINS";
+export const RAILWAY_PUBLIC_DOMAIN_ENV = "RAILWAY_PUBLIC_DOMAIN";
 type LocalOperatorBlockCode = Extract<LocalOperatorGuardDecision, { ok: false }>["code"];
 
 export function evaluateLocalOperatorRequest(input: {
@@ -108,6 +109,12 @@ function readTrustedOperatorOrigins(env: Record<string, string | undefined>) {
   for (const value of (env[AGENTOS_TRUSTED_OPERATOR_ORIGINS_ENV] ?? "").split(",")) {
     const parsed = parseHttpsOrigin(value);
     if (parsed) origins.add(parsed.origin);
+  }
+
+  const railwayDomain = env[RAILWAY_PUBLIC_DOMAIN_ENV]?.trim();
+  const railwayOrigin = railwayDomain ? parseHttpsOrigin(`https://${railwayDomain}`) : null;
+  if (railwayOrigin) {
+    origins.add(railwayOrigin.origin);
   }
 
   return origins;

--- a/packages/agentos/README.md
+++ b/packages/agentos/README.md
@@ -62,6 +62,8 @@ If AgentOS was installed with `pnpm` or `npm`, update commands only print the ma
 
 AgentOS is designed to work with a local OpenClaw installation. If OpenClaw is missing, AgentOS still starts and guides onboarding in the UI.
 
+For a hosted installation, use the repository's documented Railway deployment instead of exposing the local package launcher. It runs the pinned OpenClaw Gateway on container loopback, requires Instance Protection, and persists runtime state on a Railway volume. See `docs/deploy-on-railway.md` in the AgentOS repository.
+
 Security:
 
 - AgentOS is intended to bind locally by default; avoid exposing it publicly without your own network controls.

--- a/packages/agentos/bin/agentos.js
+++ b/packages/agentos/bin/agentos.js
@@ -32,7 +32,7 @@ const startupGracePeriodMs = 15_000;
 const updateCacheTtlMs = 24 * 60 * 60 * 1000;
 const updateWarningCooldownMs = 24 * 60 * 60 * 1000;
 const updateRequestTimeoutMs = 5_000;
-const openClawGatewayProbeTimeoutMs = 1_500;
+const openClawGatewayProbeTimeoutMs = 3_000;
 const cliSmokeTestMode = process.env.AGENTOS_CLI_TEST === "1";
 const requiredOpenClawGatewayProtocolVersion = 4;
 const requiredOpenClawGatewayMethods = [

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,12 @@ import { NextResponse, type NextRequest } from "next/server";
 import { evaluateAgentOsApiRequest, evaluateAuthenticatedAgentOsApiRequest } from "@/lib/security/api-auth";
 import { getInstanceProtectionStatus, readInstanceSessionCookie } from "@/lib/security/instance-protection";
 
-const publicInstanceApiPaths = new Set(["/api/auth/status", "/api/auth/login", "/api/auth/logout"]);
+const publicInstanceApiPaths = new Set([
+  "/api/auth/status",
+  "/api/auth/login",
+  "/api/auth/logout",
+  "/api/health"
+]);
 
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile.railway"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10,
+    "drainingSeconds": "30"
+  }
+}

--- a/scripts/railway-entrypoint.sh
+++ b/scripts/railway-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+umask 077
+
+if [ "${RAILWAY_ENVIRONMENT_ID:-}" != "" ] && [ "${RAILWAY_VOLUME_MOUNT_PATH:-}" != "/data" ]; then
+  echo "AgentOS requires a Railway volume mounted at /data." >&2
+  exit 1
+fi
+
+if [ "${OPENCLAW_GATEWAY_TOKEN:-}" = "" ]; then
+  echo "OPENCLAW_GATEWAY_TOKEN is required. Configure it with a generated Railway template secret." >&2
+  exit 1
+fi
+
+if [ "${AGENTOS_API_TOKEN:-}" = "" ]; then
+  echo "AGENTOS_API_TOKEN is required. Configure it with a generated Railway template secret." >&2
+  exit 1
+fi
+
+mkdir -p /data/agentos/mission-control /data/openclaw /data/openclaw-config /data/workspaces
+chown node:node \
+  /data \
+  /data/agentos \
+  /data/agentos/mission-control \
+  /data/openclaw \
+  /data/openclaw-config \
+  /data/workspaces
+chmod 0700 \
+  /data/agentos \
+  /data/agentos/mission-control \
+  /data/openclaw \
+  /data/openclaw-config \
+  /data/workspaces
+
+if [ ! -s /data/agentos/instance-protection.json ] && [ "${AGENTOS_INITIAL_ADMIN_PASSWORD:-}" = "" ]; then
+  echo "AGENTOS_INITIAL_ADMIN_PASSWORD is required for the first deployment." >&2
+  exit 1
+fi
+
+exec gosu node:node node /agentos/scripts/railway-supervisor.mjs

--- a/scripts/railway-supervisor.mjs
+++ b/scripts/railway-supervisor.mjs
@@ -1,0 +1,108 @@
+import { spawn } from "node:child_process";
+
+const gatewayPort = 18789;
+const gatewayEnv = { ...process.env };
+delete gatewayEnv.AGENTOS_INITIAL_ADMIN_PASSWORD;
+
+const gateway = spawn("openclaw", [
+  "gateway",
+  "run",
+  "--bind",
+  "loopback",
+  "--auth",
+  "token",
+  "--allow-unconfigured",
+  "--compact",
+  "--port",
+  String(gatewayPort)
+], {
+  env: gatewayEnv,
+  stdio: "inherit"
+});
+
+let agentos = null;
+let stopping = false;
+
+const stop = (signal = "SIGTERM") => {
+  if (stopping) return;
+  stopping = true;
+  agentos?.kill(signal);
+  gateway.kill(signal);
+};
+
+process.on("SIGTERM", () => stop("SIGTERM"));
+process.on("SIGINT", () => stop("SIGINT"));
+
+gateway.once("error", (error) => {
+  console.error(`OpenClaw Gateway could not start: ${error.message}`);
+  process.exitCode = 1;
+});
+
+try {
+  await waitForGateway();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "OpenClaw Gateway did not become ready.");
+  stop();
+  process.exit(1);
+}
+
+if (gateway.exitCode !== null) {
+  console.error(`OpenClaw Gateway exited before AgentOS started (code ${gateway.exitCode}).`);
+  process.exit(1);
+}
+
+agentos = spawn(process.execPath, ["/agentos/server.js"], {
+  env: process.env,
+  stdio: "inherit"
+});
+
+agentos.once("error", (error) => {
+  console.error(`AgentOS could not start: ${error.message}`);
+  stop();
+});
+
+const exit = await Promise.race([
+  childExit(gateway, "OpenClaw Gateway"),
+  childExit(agentos, "AgentOS")
+]);
+
+if (!stopping) {
+  console.error(`${exit.label} stopped unexpectedly (code ${exit.code ?? "unknown"}).`);
+  stop();
+}
+
+await Promise.allSettled([childExit(gateway, "OpenClaw Gateway"), childExit(agentos, "AgentOS")]);
+process.exit(stopping ? 0 : 1);
+
+async function waitForGateway() {
+  const deadline = Date.now() + 120_000;
+
+  while (Date.now() < deadline) {
+    if (gateway.exitCode !== null) {
+      throw new Error(`OpenClaw Gateway exited during startup (code ${gateway.exitCode}).`);
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${gatewayPort}/readyz`, {
+        signal: AbortSignal.timeout(1_500)
+      });
+      if (response.ok) return;
+    } catch {
+      // The Gateway may still be initializing its persistent state.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error("OpenClaw Gateway did not become ready within 120 seconds.");
+}
+
+function childExit(child, label) {
+  if (child.exitCode !== null) {
+    return Promise.resolve({ label, code: child.exitCode });
+  }
+
+  return new Promise((resolve) => {
+    child.once("exit", (code) => resolve({ label, code }));
+  });
+}

--- a/tests/agentos-security-hardening.test.ts
+++ b/tests/agentos-security-hardening.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, stat, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -22,17 +22,21 @@ const rootDir = process.cwd();
 
 async function withProcessEnv(
   env: Partial<
-    Record<"AGENTOS_API_TOKEN" | "AGENTOS_PACKAGE_RUNTIME" | "AGENTOS_TRUSTED_OPERATOR_ORIGINS" | "AGENTOS_UNSAFE_DISABLE_API_AUTH" | "NODE_ENV", string | undefined>
+    Record<"AGENTOS_API_TOKEN" | "AGENTOS_PACKAGE_RUNTIME" | "AGENTOS_RUNTIME_DIR" | "AGENTOS_TRUSTED_OPERATOR_ORIGINS" | "AGENTOS_UNSAFE_DISABLE_API_AUTH" | "NODE_ENV", string | undefined>
   >,
   callback: () => Promise<void> | void
 ) {
+  const isolatedRuntimeDir = await mkdtemp(path.join(tmpdir(), "agentos-security-runtime-"));
   const previous = {
     AGENTOS_API_TOKEN: process.env.AGENTOS_API_TOKEN,
     AGENTOS_PACKAGE_RUNTIME: process.env.AGENTOS_PACKAGE_RUNTIME,
+    AGENTOS_RUNTIME_DIR: process.env.AGENTOS_RUNTIME_DIR,
     AGENTOS_TRUSTED_OPERATOR_ORIGINS: process.env.AGENTOS_TRUSTED_OPERATOR_ORIGINS,
     AGENTOS_UNSAFE_DISABLE_API_AUTH: process.env.AGENTOS_UNSAFE_DISABLE_API_AUTH,
     NODE_ENV: process.env.NODE_ENV
   };
+
+  process.env.AGENTOS_RUNTIME_DIR = env.AGENTOS_RUNTIME_DIR ?? isolatedRuntimeDir;
 
   for (const [key, value] of Object.entries(env)) {
     if (value === undefined) {
@@ -52,6 +56,7 @@ async function withProcessEnv(
         process.env[key] = value;
       }
     }
+    await rm(isolatedRuntimeDir, { recursive: true, force: true });
   }
 }
 
@@ -66,6 +71,38 @@ test("local same-origin mutation requests are allowed", () => {
   });
 
   assert.deepEqual(decision, { ok: true });
+});
+
+test("Railway public domain is treated as an exact trusted HTTPS operator origin", () => {
+  const decision = evaluateLocalOperatorRequest({
+    method: "POST",
+    url: "https://agentos-production.up.railway.app/api/mission",
+    headers: new Headers({
+      host: "agentos-production.up.railway.app",
+      origin: "https://agentos-production.up.railway.app",
+      "x-forwarded-for": "203.0.113.20",
+      "x-forwarded-host": "agentos-production.up.railway.app",
+      "x-forwarded-proto": "https"
+    }),
+    env: { RAILWAY_PUBLIC_DOMAIN: "agentos-production.up.railway.app" }
+  });
+
+  assert.deepEqual(decision, { ok: true });
+
+  const mismatchedOrigin = evaluateLocalOperatorRequest({
+    method: "POST",
+    url: "https://agentos-production.up.railway.app/api/mission",
+    headers: new Headers({
+      host: "agentos-production.up.railway.app",
+      origin: "https://attacker.example.com",
+      "x-forwarded-for": "203.0.113.20",
+      "x-forwarded-host": "agentos-production.up.railway.app",
+      "x-forwarded-proto": "https"
+    }),
+    env: { RAILWAY_PUBLIC_DOMAIN: "agentos-production.up.railway.app" }
+  });
+
+  assert.equal(mismatchedOrigin.ok, false);
 });
 
 test("forwarded loopback mutation requests are allowed", () => {

--- a/tests/instance-protection.test.ts
+++ b/tests/instance-protection.test.ts
@@ -8,6 +8,7 @@ import { test } from "node:test";
 import { NextRequest } from "next/server";
 
 import { POST as loginRoute } from "@/app/api/auth/login/route";
+import { bootstrapInitialInstanceProtection } from "@/lib/security/initial-instance-bootstrap";
 import {
   disableInstanceProtection,
   enableInstanceProtection,
@@ -18,6 +19,38 @@ import {
   updateInstanceCredentials
 } from "@/lib/security/instance-protection";
 import { proxy } from "@/proxy";
+
+test("deployment bootstrap creates Instance Protection once and removes the password from process state", async () => {
+  const runtimeDir = await mkdtemp(path.join(tmpdir(), "agentos-instance-bootstrap-"));
+  const env = {
+    ...process.env,
+    AGENTOS_RUNTIME_DIR: runtimeDir,
+    AGENTOS_INITIAL_ADMIN_USERNAME: "railway-owner",
+    AGENTOS_INITIAL_ADMIN_PASSWORD: "initial secure password"
+  };
+
+  assert.deepEqual(await bootstrapInitialInstanceProtection(env), { status: "created" });
+  assert.equal(env.AGENTOS_INITIAL_ADMIN_PASSWORD, undefined);
+
+  const login = await loginToInstance({
+    username: "railway-owner",
+    password: "initial secure password",
+    rateKey: "bootstrap-login"
+  }, env);
+  assert.equal(login.status.authenticated, true);
+
+  env.AGENTOS_INITIAL_ADMIN_PASSWORD = "replacement password";
+  assert.deepEqual(await bootstrapInitialInstanceProtection(env), { status: "already-configured" });
+  assert.equal(env.AGENTOS_INITIAL_ADMIN_PASSWORD, undefined);
+  await assert.rejects(
+    loginToInstance({
+      username: "railway-owner",
+      password: "replacement password",
+      rateKey: "bootstrap-replacement"
+    }, env),
+    /Invalid username or password/
+  );
+});
 
 test("instance protection lifecycle hashes credentials and invalidates old sessions", async () => {
   const runtimeDir = await mkdtemp(path.join(tmpdir(), "agentos-instance-protection-"));
@@ -122,6 +155,9 @@ test("proxy protects UI, setup, and sensitive APIs while leaving auth endpoints 
       headers: { host: "localhost:3000", origin: "http://localhost:3000" }
     }));
     assert.equal(login.status, 200);
+
+    const health = await proxy(new NextRequest("http://healthcheck.railway.app/api/health"));
+    assert.equal(health.status, 200);
 
     const sessionOnly = await proxy(new NextRequest("http://localhost:3000/api/snapshot", {
       headers: {

--- a/tests/openclaw-boundary-safety.test.ts
+++ b/tests/openclaw-boundary-safety.test.ts
@@ -645,6 +645,8 @@ test("workspace creation provides a compact mobile-first basic flow", () => {
 
 test("mission shell supports hover and pinned sidebar modes", () => {
   const source = readFileSync(path.join(rootDir, "components/mission-control/mission-control-shell.tsx"), "utf8");
+  const mobileSettingsHeaderStart = source.indexOf('"fixed inset-x-0 top-0 z-[60] flex min-h-16');
+  const mobileSettingsHeaderEnd = source.indexOf('"pointer-events-auto fixed inset-y-0 left-0 z-50', mobileSettingsHeaderStart);
 
   assert.match(source, /const \[isSidebarOpenState, setIsSidebarOpen\] = useState\(false\);/);
   assert.match(source, /const \[isCompactViewport, setIsCompactViewport\] = useState\(false\);/);
@@ -672,11 +674,14 @@ test("mission shell supports hover and pinned sidebar modes", () => {
   assert.match(source, /isSidebarOpen \? "translate-x-0" : "-translate-x-full"/);
   assert.match(source, /aria-label=\{isInspectorOpen \? "Close inspector" : "Open inspector"\}/);
   assert.equal(source.match(/<MissionControlCanvasTitlePill surfaceTheme=\{surfaceTheme\} \/>/g)?.length, 1);
+  assert.ok(mobileSettingsHeaderStart >= 0 && mobileSettingsHeaderEnd > mobileSettingsHeaderStart);
+  assert.doesNotMatch(source.slice(mobileSettingsHeaderStart, mobileSettingsHeaderEnd), /connectionState/);
   assert.doesNotMatch(source, /sidebarOpenStorageKey/);
 });
 
 test("operations shell shares the persistent pinned sidebar behavior", () => {
   const source = readFileSync(path.join(rootDir, "components/operations/operations-shell.tsx"), "utf8");
+  const operationsUiSource = readFileSync(path.join(rootDir, "components/operations/operations-ui.tsx"), "utf8");
   const pinningSource = readFileSync(
     path.join(rootDir, "components/mission-control/use-sidebar-pinning.ts"),
     "utf8"
@@ -688,6 +693,8 @@ test("operations shell shares the persistent pinned sidebar behavior", () => {
   assert.match(source, /if \(!isSidebarPinned\) setSidebarExpanded\(false\);/);
   assert.match(pinningSource, /agentos\.sidebar\.pinned/);
   assert.match(pinningSource, /window\.localStorage\.setItem\(sidebarPinnedStorageKey, String\(nextPinned\)\)/);
+  assert.match(operationsUiSource, /\{!compact \? \(\s*<span/);
+  assert.doesNotMatch(operationsUiSource, /compact \? "h-11 px-3"/);
 });
 
 test("command bar collapses when empty on mobile and desktop", () => {

--- a/tests/openclaw-boundary-safety.test.ts
+++ b/tests/openclaw-boundary-safety.test.ts
@@ -608,6 +608,10 @@ test("sidebar keeps its header and user footer fixed around scrollable navigatio
   assert.match(source, /profile\.email\.trim\(\) \|\| \(profile\.username\.trim\(\) \? `@\$\{profile\.username\.trim\(\)\}` : "Personal account"\)/);
   assert.match(source, /<UserProfileDialog[\s\S]*?open=\{profileOpen\}/);
   assert.match(source, /onProfileSaved=\{onProfileSaved\}/);
+  assert.match(source, /<SidebarThemeMenuAction surfaceTheme=\{surfaceTheme\} onToggle=\{onToggleTheme\} \/>/);
+  assert.match(source, /role="menuitemcheckbox"/);
+  assert.match(source, /aria-checked=\{isDark\}/);
+  assert.match(source, /<span>Appearance<\/span>/);
 });
 
 test("settings shell no longer hardcodes a light-only wrapper", () => {

--- a/tests/openclaw-boundary-safety.test.ts
+++ b/tests/openclaw-boundary-safety.test.ts
@@ -626,6 +626,23 @@ test("settings shell no longer hardcodes a light-only wrapper", () => {
   assert.match(source, /isSidebarOpen \? "lg:left-\[316px\]" : "lg:left-\[80px\]"/);
 });
 
+test("workspace creation provides a compact mobile-first basic flow", () => {
+  const source = readFileSync(
+    path.join(rootDir, "components/mission-control/workspace-wizard/workspace-wizard-dialog.tsx"),
+    "utf8"
+  );
+
+  assert.match(source, /contentClassName="h-\[100dvh\] max-h-\[100dvh\] w-screen rounded-none/);
+  assert.match(source, /<MobileWorkspaceCreateForm/);
+  assert.match(source, /id="mobile-workspace-name"/);
+  assert.match(source, /id="mobile-workspace-goal"/);
+  assert.match(source, /id="mobile-workspace-source"/);
+  assert.match(source, /id="mobile-workspace-template"/);
+  assert.match(source, /Core team · Balanced model · Standard setup/);
+  assert.match(source, /className="flex w-full items-center gap-2 md:hidden"/);
+  assert.match(source, /onClick=\{\(\) => void onCreateWorkspace\(\)\}/);
+});
+
 test("mission shell supports hover and pinned sidebar modes", () => {
   const source = readFileSync(path.join(rootDir, "components/mission-control/mission-control-shell.tsx"), "utf8");
 
@@ -654,6 +671,7 @@ test("mission shell supports hover and pinned sidebar modes", () => {
   assert.match(source, /aria-label=\{isSidebarOpen \? "Close navigation" : "Open navigation"\}/);
   assert.match(source, /isSidebarOpen \? "translate-x-0" : "-translate-x-full"/);
   assert.match(source, /aria-label=\{isInspectorOpen \? "Close inspector" : "Open inspector"\}/);
+  assert.equal(source.match(/<MissionControlCanvasTitlePill surfaceTheme=\{surfaceTheme\} \/>/g)?.length, 1);
   assert.doesNotMatch(source, /sidebarOpenStorageKey/);
 });
 

--- a/tests/railway-deployment.test.ts
+++ b/tests/railway-deployment.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { test } from "node:test";
+
+const rootDir = process.cwd();
+
+test("Railway config uses the dedicated container and readiness endpoint", async () => {
+  const config = JSON.parse(await read("railway.json")) as {
+    build?: { builder?: string; dockerfilePath?: string };
+    deploy?: { healthcheckPath?: string; restartPolicyType?: string };
+  };
+
+  assert.equal(config.build?.builder, "DOCKERFILE");
+  assert.equal(config.build?.dockerfilePath, "Dockerfile.railway");
+  assert.equal(config.deploy?.healthcheckPath, "/api/health");
+  assert.equal(config.deploy?.restartPolicyType, "ON_FAILURE");
+});
+
+test("Railway image pins OpenClaw and maps every mutable runtime root to the volume", async () => {
+  const dockerfile = await read("Dockerfile.railway");
+
+  assert.match(dockerfile, /ghcr\.io\/openclaw\/openclaw:2026\.6\.11@sha256:[a-f0-9]{64}/);
+  assert.match(dockerfile, /AGENTOS_RUNTIME_DIR=\/data\/agentos/);
+  assert.match(dockerfile, /OPENCLAW_STATE_DIR=\/data\/openclaw/);
+  assert.match(dockerfile, /\/data\/agentos\/mission-control/);
+  assert.match(dockerfile, /\/data\/workspaces/);
+  assert.match(dockerfile, /gosu/);
+});
+
+test("Railway supervisor keeps Gateway private and excludes the bootstrap password", async () => {
+  const supervisor = await read("scripts/railway-supervisor.mjs");
+  const entrypoint = await read("scripts/railway-entrypoint.sh");
+
+  assert.match(supervisor, /delete gatewayEnv\.AGENTOS_INITIAL_ADMIN_PASSWORD/);
+  assert.match(supervisor, /"--bind",\s*"loopback"/);
+  assert.match(supervisor, /"--auth",\s*"token"/);
+  assert.doesNotMatch(supervisor, /"--token"/);
+  assert.match(entrypoint, /RAILWAY_VOLUME_MOUNT_PATH:-.*\/data/);
+  assert.match(entrypoint, /exec gosu node:node/);
+});
+
+async function read(relativePath: string) {
+  return await readFile(path.join(rootDir, relativePath), "utf8");
+}


### PR DESCRIPTION
## Summary
Add a production-oriented Railway deployment path for AgentOS and OpenClaw in one persistent service.

## Changes
- Add the pinned AgentOS/OpenClaw Railway container, supervisor, healthcheck, and volume bootstrap
- Bootstrap Instance Protection securely for multi-browser hosted access
- Trust the exact Railway HTTPS domain and document custom-domain handling
- Add deployment, security, and container contract tests

## Notes
- The Railway template must use one replica and mount a volume at `/data`
- Internal AgentOS and Gateway tokens should be generated as hidden template secrets
- The public Deploy on Railway button requires the template code assigned after Railway template publication
- Validation: lint, typecheck, release consistency, 869 tests, Docker build, and container smoke checks passed