### PR TITLE
docs(runtime): add live Railway deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ AgentOS is being built for that layer: the place where a person can turn individ
 
 ### Deploy on Railway
 
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/agentos-1?utm_medium=integration&utm_source=button&utm_campaign=agentos)
+
 AgentOS includes a production-oriented Railway deployment path that runs AgentOS and the pinned OpenClaw Gateway together in one service. The deployment uses one persistent `/data` volume, keeps the Gateway on container loopback, initializes Instance Protection from the username and password supplied during deployment, and waits for both runtimes before passing Railway's healthcheck.
 
-The public one-click button requires a published Railway template code. Until the official template is published, use the exact template composer specification in [`docs/deploy-on-railway.md`](docs/deploy-on-railway.md). Do not deploy this repository as a stateless service: the `/data` volume and generated internal tokens are required.
+The official published Railway template provisions the required `/data` volume and generates the internal AgentOS and OpenClaw tokens automatically. The only required operator input is the initial administrator password. See [`docs/deploy-on-railway.md`](docs/deploy-on-railway.md) for the complete runtime and security model.
 
 After the first deployment:
 

--- a/docs/deploy-on-railway.md
+++ b/docs/deploy-on-railway.md
@@ -86,16 +86,17 @@ Back up the Railway volume before risky upgrades. A service with an attached vol
 
 OpenClaw is pinned in `Dockerfile.railway`. Upgrade it only together with AgentOS compatibility checks and update the pin, recommended version, and deployment documentation in the same change.
 
-## Publishing the one-click button
+## Published one-click template
 
-Railway assigns the template code only after the template is created in the Railway workspace. Once created and test-deployed:
+The official AgentOS template is published in the Railway marketplace:
 
-1. Publish the template.
-2. Copy its template code from Railway.
-3. Add Railway's official button to the README, replacing `<TEMPLATE_CODE>`:
+- Template page: [railway.com/deploy/agentos-1](https://railway.com/deploy/agentos-1)
+- Direct deployment: [railway.com/new/template/agentos-1](https://railway.com/new/template/agentos-1)
+
+The README uses Railway's official button:
 
 ```md
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/<TEMPLATE_CODE>?utm_medium=integration&utm_source=template&utm_campaign=agentos)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/agentos-1?utm_medium=integration&utm_source=button&utm_campaign=agentos)
 ```
 
-Do not merge a placeholder template code. Verify the button in a signed-out browser and complete a clean deployment before calling the one-click flow available.
+When the runtime contract changes, update the Railway template and this guide together. Verify the public template page, deploy form, required password field, generated secrets, `/data` volume, and healthcheck before publishing an update.


### PR DESCRIPTION
## Summary
Add the live published AgentOS Railway template to the project documentation.

## Changes
- Add the official Deploy on Railway button to the README
- Replace the template publishing placeholder with the public marketplace and direct deployment links

## Notes
- Published template: https://railway.com/deploy/agentos-1
- Direct deployment form, required password, generated secrets, and `/data` volume were verified
- No Railway project was deployed during form validation