### PR TITLE
fix(runtime): remove Railway cache mounts

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -8,8 +8,7 @@ RUN corepack enable
 WORKDIR /build
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN --mount=type=cache,id=agentos-pnpm-store,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 COPY . .
 RUN pnpm build
@@ -18,9 +17,7 @@ FROM ghcr.io/openclaw/openclaw:2026.6.11@sha256:3814fb1f62f9cfc5944de088c5817c68
 
 USER root
 
-RUN --mount=type=cache,id=agentos-bookworm-apt,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=agentos-bookworm-apt-lists,target=/var/lib/apt/lists,sharing=locked \
-    apt-get update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       chromium \
       chromium-sandbox \

--- a/tests/railway-deployment.test.ts
+++ b/tests/railway-deployment.test.ts
@@ -22,10 +22,11 @@ test("Railway config uses the dedicated container and readiness endpoint", async
   assert.equal(config.deploy?.drainingSeconds, 30);
 });
 
-test("Railway image pins OpenClaw and maps every mutable runtime root to the volume", async () => {
+test("Railway image pins OpenClaw, avoids service-bound cache mounts, and maps every mutable runtime root to the volume", async () => {
   const dockerfile = await read("Dockerfile.railway");
 
   assert.match(dockerfile, /ghcr\.io\/openclaw\/openclaw:2026\.6\.11@sha256:[a-f0-9]{64}/);
+  assert.doesNotMatch(dockerfile, /--mount=type=cache/);
   assert.match(dockerfile, /AGENTOS_RUNTIME_DIR=\/data\/agentos/);
   assert.match(dockerfile, /OPENCLAW_STATE_DIR=\/data\/openclaw/);
   assert.match(dockerfile, /\/data\/agentos\/mission-control/);


### PR DESCRIPTION
## Summary

Fixes Railway Dockerfile builds rejected before the first build step.

## Changes

- Removes service-bound BuildKit cache mounts from the Railway Dockerfile.
- Keeps the package install and system package install steps intact.
- Adds a regression assertion that the reusable template has no cache mounts requiring a Railway service ID.

## Notes

Railway requires cache mount IDs to include the generated service ID, which cannot be hard-coded in a reusable one-click template. Builds may be slightly slower without those mounts, but deployment is portable and valid. Validated with focused Railway tests, lint, typecheck, release consistency, and a full local Docker build.