### PR TITLE
fix(runtime): defer Railway public port selection

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -57,6 +57,4 @@ ENV NODE_ENV=production \
     OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789 \
     CHROME_BIN=/usr/bin/chromium
 
-EXPOSE 3000
-
 ENTRYPOINT ["tini", "-s", "--", "/agentos/scripts/railway-entrypoint.sh"]

--- a/tests/railway-deployment.test.ts
+++ b/tests/railway-deployment.test.ts
@@ -29,6 +29,7 @@ test("Railway image pins OpenClaw, avoids service-bound cache mounts, and maps e
   assert.doesNotMatch(dockerfile, /--mount=type=cache/);
   assert.match(dockerfile, /AGENTOS_RUNTIME_DIR=\/data\/agentos/);
   assert.match(dockerfile, /OPENCLAW_STATE_DIR=\/data\/openclaw/);
+  assert.doesNotMatch(dockerfile, /EXPOSE\s+3000/);
   assert.match(dockerfile, /\/data\/agentos\/mission-control/);
   assert.match(dockerfile, /\/data\/workspaces/);
   assert.match(dockerfile, /gosu/);


### PR DESCRIPTION
## Summary

Fixes Railway public domains being pre-routed to port 3000 while Railway provides the application `PORT` dynamically.

## Changes

- Removes the fixed `EXPOSE 3000` declaration from the Railway image.
- Lets Railway route a generated public domain to its runtime `PORT`, as required for reusable templates.
- Adds a regression assertion preventing the fixed port declaration from returning.

## Notes

The affected deployment was listening on Railway's supplied port 8080, while its public domain target was configured for 3000, producing a 502 response. Focused tests, lint, typecheck, and release consistency checks pass.