### PR TITLE
fix(runtime): bind Railway web service to port 3000

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -57,4 +57,6 @@ ENV NODE_ENV=production \
     OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789 \
     CHROME_BIN=/usr/bin/chromium
 
+EXPOSE 3000
+
 ENTRYPOINT ["tini", "-s", "--", "/agentos/scripts/railway-entrypoint.sh"]

--- a/scripts/railway-supervisor.mjs
+++ b/scripts/railway-supervisor.mjs
@@ -52,7 +52,10 @@ if (gateway.exitCode !== null) {
 }
 
 agentos = spawn(process.execPath, ["/agentos/server.js"], {
-  env: process.env,
+  env: {
+    ...process.env,
+    PORT: "3000"
+  },
   stdio: "inherit"
 });
 

--- a/tests/railway-deployment.test.ts
+++ b/tests/railway-deployment.test.ts
@@ -29,7 +29,7 @@ test("Railway image pins OpenClaw, avoids service-bound cache mounts, and maps e
   assert.doesNotMatch(dockerfile, /--mount=type=cache/);
   assert.match(dockerfile, /AGENTOS_RUNTIME_DIR=\/data\/agentos/);
   assert.match(dockerfile, /OPENCLAW_STATE_DIR=\/data\/openclaw/);
-  assert.doesNotMatch(dockerfile, /EXPOSE\s+3000/);
+  assert.match(dockerfile, /EXPOSE\s+3000/);
   assert.match(dockerfile, /\/data\/agentos\/mission-control/);
   assert.match(dockerfile, /\/data\/workspaces/);
   assert.match(dockerfile, /gosu/);
@@ -40,6 +40,7 @@ test("Railway supervisor keeps Gateway private and excludes the bootstrap passwo
   const entrypoint = await read("scripts/railway-entrypoint.sh");
 
   assert.match(supervisor, /delete gatewayEnv\.AGENTOS_INITIAL_ADMIN_PASSWORD/);
+  assert.match(supervisor, /PORT:\s*"3000"/);
   assert.match(supervisor, /"--bind",\s*"loopback"/);
   assert.match(supervisor, /"--auth",\s*"token"/);
   assert.doesNotMatch(supervisor, /"--token"/);


### PR DESCRIPTION
## Summary

Fixes Railway public domains returning 502 when the generated domain targets port 3000.

## Changes

- Makes the Railway supervisor start the AgentOS web server on port 3000.
- Restores the matching Docker port declaration so Railway-generated domains target the same stable service port.
- Adds regression coverage for the fixed runtime port.

## Notes

The affected Railway service was online, but its public domain targeted 3000 while Next.js inherited Railway's dynamic 8080 value. Gateway remains private on loopback.