### PR TITLE
fix(runtime): restore Railway dynamic port

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -57,6 +57,4 @@ ENV NODE_ENV=production \
     OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789 \
     CHROME_BIN=/usr/bin/chromium
 
-EXPOSE 3000
-
 ENTRYPOINT ["tini", "-s", "--", "/agentos/scripts/railway-entrypoint.sh"]

--- a/scripts/railway-supervisor.mjs
+++ b/scripts/railway-supervisor.mjs
@@ -52,10 +52,7 @@ if (gateway.exitCode !== null) {
 }
 
 agentos = spawn(process.execPath, ["/agentos/server.js"], {
-  env: {
-    ...process.env,
-    PORT: "3000"
-  },
+  env: process.env,
   stdio: "inherit"
 });
 

--- a/tests/railway-deployment.test.ts
+++ b/tests/railway-deployment.test.ts
@@ -29,7 +29,7 @@ test("Railway image pins OpenClaw, avoids service-bound cache mounts, and maps e
   assert.doesNotMatch(dockerfile, /--mount=type=cache/);
   assert.match(dockerfile, /AGENTOS_RUNTIME_DIR=\/data\/agentos/);
   assert.match(dockerfile, /OPENCLAW_STATE_DIR=\/data\/openclaw/);
-  assert.match(dockerfile, /EXPOSE\s+3000/);
+  assert.doesNotMatch(dockerfile, /EXPOSE\s+3000/);
   assert.match(dockerfile, /\/data\/agentos\/mission-control/);
   assert.match(dockerfile, /\/data\/workspaces/);
   assert.match(dockerfile, /gosu/);
@@ -40,7 +40,7 @@ test("Railway supervisor keeps Gateway private and excludes the bootstrap passwo
   const entrypoint = await read("scripts/railway-entrypoint.sh");
 
   assert.match(supervisor, /delete gatewayEnv\.AGENTOS_INITIAL_ADMIN_PASSWORD/);
-  assert.match(supervisor, /PORT:\s*"3000"/);
+  assert.doesNotMatch(supervisor, /PORT:\s*"3000"/);
   assert.match(supervisor, /"--bind",\s*"loopback"/);
   assert.match(supervisor, /"--auth",\s*"token"/);
   assert.doesNotMatch(supervisor, /"--token"/);


### PR DESCRIPTION
## Summary
Restore Railway's platform-provided runtime port so the configured healthcheck can reach AgentOS.

## Changes
- Remove the static Docker port declaration.
- Pass Railway's `PORT` through to the AgentOS server.
- Guard the deployment contract against reintroducing a static port.

## Notes
The previous static `3000` override caused the Railway healthcheck to return 503 even though the process started.